### PR TITLE
BREAKING CHANGES: Output path will be resolved from config directory.

### DIFF
--- a/__tests__/config/circleci_config.test.ts
+++ b/__tests__/config/circleci_config.test.ts
@@ -4,6 +4,7 @@ describe('parseConfig', () => {
   describe('repos', () => {
     it('vscType should github when value is repo string', () => {
       const config = {
+        configDir: __dirname,
         circleci: {
           repos: [ 'owner/repo' ]
         }
@@ -22,6 +23,7 @@ describe('parseConfig', () => {
 
     it('vscType should same as provides when value is object', () => {
       const config = {
+        configDir: __dirname,
         circleci: {
           repos: [{ name: 'owner/repo', vsc_type: 'bitbucket' }]
         }
@@ -40,6 +42,7 @@ describe('parseConfig', () => {
 
     it('vscType should github when object vsc_type is null', () => {
       const config = {
+        configDir: __dirname,
         circleci: {
           repos: [{ name: 'owner/repo' }]
         }

--- a/__tests__/config/github_config.test.ts
+++ b/__tests__/config/github_config.test.ts
@@ -2,6 +2,7 @@ import { parseConfig } from '../../src/config/github_config'
 
 describe('parseConfig', () => {
   const config = {
+    configDir: __dirname,
     github: {
       repos: [
         'owner/repo'

--- a/__tests__/config/jenkins_config.test.ts
+++ b/__tests__/config/jenkins_config.test.ts
@@ -4,6 +4,7 @@ describe('parseConfig', () => {
   describe('repos', () => {
     it('should have valid job names', () => {
       const config = {
+        configDir: __dirname,
         jenkins: {
           baseUrl: 'http://localhost:8080',
           jobs: [ 'sample-job' ]

--- a/__tests__/exporter/local_exporter.test.ts
+++ b/__tests__/exporter/local_exporter.test.ts
@@ -3,13 +3,13 @@ import path from 'path'
 
 describe('LocalExporter', () => {
   describe('new', () => {
-    it('should all set with default parameter when options is null', async () => {
+    it('should all property set with default parameter when options is null', async () => {
+      const configDir = __dirname
       // Argument type does not accept null, but some case js-yaml returns 'null' as exporter options
-      const exporter = new LocalExporter('github', null as any )
+      const exporter = new LocalExporter('github', configDir, null as any )
 
-      expect(exporter.outDir).toEqual(path.resolve('output'))
+      expect(exporter.outDir).toEqual(path.resolve(configDir, 'output'))
       expect(exporter.formatter).toEqual(exporter.formatJson)
-
     })
   })
 })

--- a/__tests__/store/local_store.test.ts
+++ b/__tests__/store/local_store.test.ts
@@ -15,7 +15,8 @@ describe('LocalStore', () => {
       os.tmpdir(),
       `${createRandomStr()}.json`
     )
-    localStore = new LocalStore('test', storePath)
+    const configDir = path.dirname(storePath)
+    localStore = new LocalStore('test', configDir, storePath)
   })
   afterEach(async () => {
     try {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,10 +1,12 @@
 import fs from 'fs'
+import path from 'path'
 import yaml from 'js-yaml'
 
 export type YamlConfig = {
-  'github'?: { [key: string]: any }
-  'circleci'?: { [key: string]: any }
-  'jenkins'?: { [key: string]: any }
+  configDir: string
+  github?: { [key: string]: any }
+  circleci?: { [key: string]: any }
+  jenkins?: { [key: string]: any }
 }
 
 export type CommonConfig = {
@@ -28,7 +30,7 @@ export type LastRunStoreConfig = {
   backend: 'gcs'
   project: string
   bucket: string
-  path: string
+  path?: string
 }
 
 const defaultPath = './ci_analyzer.yaml'
@@ -37,6 +39,7 @@ export const loadConfig = (configPath?: string): YamlConfig => {
   configPath = configPath ?? defaultPath
 
   const config = yaml.safeLoad(fs.readFileSync(configPath, 'utf8'))
+  config.configDir = path.dirname(path.resolve(configPath))
 
   if (process.env['CI_ANALYZER_DEBUG']) {
     console.debug('Parsed config file:')

--- a/src/exporter/exporter.ts
+++ b/src/exporter/exporter.ts
@@ -9,16 +9,16 @@ export interface Exporter {
 
 export class CompositExporter implements Exporter {
   exporters: (Exporter | undefined)[]
-  constructor(service: string, config?: ExporterConfig) {
+  constructor(service: string, configDir: string, config?: ExporterConfig) {
     if (!config) {
-      this.exporters = [ new LocalExporter(service) ]
+      this.exporters = [ new LocalExporter(service, configDir) ]
       return
     }
 
     this.exporters = Object.entries(config).map(([exporter, options]) => {
       switch (exporter) {
         case 'local':
-          return new LocalExporter(service, { outDir: options.outDir, format: options.format })
+          return new LocalExporter(service, configDir, { outDir: options.outDir, format: options.format })
         case 'bigquery':
           return new BigqueryExporter(options.project, options.dataset, options.table, { maxBadRecords: options.maxBadRecords })
         default:

--- a/src/exporter/local_exporter.ts
+++ b/src/exporter/local_exporter.ts
@@ -13,12 +13,14 @@ export class LocalExporter implements Exporter {
   formatter: (report: WorkflowReport[]) => string
   constructor(
     service: string,
+    configDir: string,
     options?: { outDir?: string, format?: Format }
   ) {
     this.service = service
-    this.outDir = (options?.outDir)
-      ? path.resolve(options.outDir)
-      : path.resolve(defaultOutDir)
+    const _outDir = options?.outDir ?? defaultOutDir
+    this.outDir = (path.isAbsolute(_outDir))
+      ? _outDir
+      : path.resolve(configDir, _outDir)
     const format = options?.format ?? 'json'
     this.formatter = (format === 'json') ? this.formatJson : this.formatJsonLines
   }

--- a/src/last_run_store.ts
+++ b/src/last_run_store.ts
@@ -14,13 +14,13 @@ export class LastRunStore {
   store: Store
   lastRun: LastRun
 
-  static async init(service: string, config?: LastRunStoreConfig) {
+  static async init(service: string, configDir: string, config?: LastRunStoreConfig) {
     let store
     if (!config) {
-      store = new LocalStore(service)
+      store = new LocalStore(service, configDir)
     }
     else if (config.backend === 'local') {
-      store = new LocalStore(service, config.path)
+      store = new LocalStore(service, configDir, config.path)
     }
     else if (config.backend === 'gcs') {
       store = new GcsStore(service, config.project, config.bucket, config.path)

--- a/src/runner/circleci_runner.ts
+++ b/src/runner/circleci_runner.ts
@@ -13,11 +13,13 @@ export class CircleciRunner implements Runner {
   service: string = 'circleci'
   client: CircleciClient
   analyzer: CircleciAnalyzer 
+  configDir: string
   config: CircleciConfig | undefined
   store?: LastRunStore
   repoClient: GithubRepositoryClient
   constructor(public yamlConfig: YamlConfig) {
     const CIRCLECI_TOKEN = process.env['CIRCLECI_TOKEN'] || ''
+    this.configDir = yamlConfig.configDir
     this.config = parseConfig(yamlConfig)
     this.client = new CircleciClient(CIRCLECI_TOKEN, this.config?.baseUrl)
     this.analyzer = new CircleciAnalyzer()
@@ -35,7 +37,7 @@ export class CircleciRunner implements Runner {
 
   async run () {
     if (!this.config) return
-    this.store = await LastRunStore.init(this.service, this.config?.lastRunStore)
+    this.store = await LastRunStore.init(this.service, this.configDir, this.config.lastRunStore)
 
     let reports: WorkflowReport[] = []
     for (const repo of this.config.repos) {

--- a/src/runner/circleci_runner.ts
+++ b/src/runner/circleci_runner.ts
@@ -74,7 +74,7 @@ export class CircleciRunner implements Runner {
     }
 
     console.info(`Exporting ${this.service} workflow reports ...`)
-    const exporter = new CompositExporter(this.service, this.config.exporter)
+    const exporter = new CompositExporter(this.service, this.configDir, this.config.exporter)
     await exporter.exportReports(reports)
 
     this.store.save()

--- a/src/runner/github_runner.ts
+++ b/src/runner/github_runner.ts
@@ -65,7 +65,7 @@ export class GithubRunner implements Runner {
     }
 
     console.info(`Exporting ${this.service} workflow reports ...`)
-    const exporter = new CompositExporter(this.service, this.config.exporter)
+    const exporter = new CompositExporter(this.service, this.configDir, this.config.exporter)
     await exporter.exportReports(reports)
 
     this.store.save()

--- a/src/runner/github_runner.ts
+++ b/src/runner/github_runner.ts
@@ -13,11 +13,13 @@ export class GithubRunner implements Runner {
   service: string = 'github'
   client: GithubClient
   analyzer: GithubAnalyzer 
+  configDir: string
   config: GithubConfig | undefined
   store?: LastRunStore
   repoClient: GithubRepositoryClient
   constructor(public yamlConfig: YamlConfig) {
     const GITHUB_TOKEN = process.env['GITHUB_TOKEN'] || ''
+    this.configDir = yamlConfig.configDir
     this.config = parseConfig(yamlConfig)
     this.client = new GithubClient(GITHUB_TOKEN)
     this.analyzer = new GithubAnalyzer()
@@ -33,7 +35,7 @@ export class GithubRunner implements Runner {
 
   async run () {
     if (!this.config) return
-    this.store = await LastRunStore.init(this.service, this.config?.lastRunStore)
+    this.store = await LastRunStore.init(this.service, this.configDir, this.config.lastRunStore)
 
     let reports: WorkflowReport[] = []
     for (const repo of this.config.repos) {

--- a/src/runner/jenkins_runner.ts
+++ b/src/runner/jenkins_runner.ts
@@ -69,7 +69,7 @@ export class JenkinsRunner implements Runner {
     }
 
     console.info(`Exporting ${this.service} workflow reports ...`)
-    const exporter = new CompositExporter(this.service, this.config.exporter)
+    const exporter = new CompositExporter(this.service, this.configDir, this.config.exporter)
     await exporter.exportReports(reports)
 
     this.store.save()

--- a/src/runner/jenkins_runner.ts
+++ b/src/runner/jenkins_runner.ts
@@ -12,9 +12,11 @@ export class JenkinsRunner implements Runner {
   service: string = 'jenkins'
   client: JenkinsClient | undefined
   analyzer: JenkinsAnalyzer 
+  configDir: string
   config: JenkinsConfig | undefined
   store?: LastRunStore
   constructor(public yamlConfig: YamlConfig) {
+    this.configDir = yamlConfig.configDir
     this.config = parseConfig(yamlConfig)
     this.analyzer = new JenkinsAnalyzer()
 
@@ -34,7 +36,7 @@ export class JenkinsRunner implements Runner {
   async run () {
     if (!this.config) return
     if (!this.client) return
-    this.store = await LastRunStore.init(this.service, this.config?.lastRunStore)
+    this.store = await LastRunStore.init(this.service, this.configDir, this.config.lastRunStore)
 
     const allJobs = await this.client.fetchJobs()
     const configJobs = this.config.jobs

--- a/src/store/local_store.ts
+++ b/src/store/local_store.ts
@@ -6,11 +6,12 @@ const defaultDir = path.join('.ci_analyzer', 'last_run')
 
 export class LocalStore implements Store {
   filePath: string
-  constructor(service: string, filePath?: string) {
+  constructor(service: string, configDir: string, filePath?: string) {
 
-  this.filePath = (filePath)
-    ? path.resolve(filePath)
-    : path.resolve(path.join(defaultDir, `${service}.json`))
+    const _filePath = filePath ?? path.join(defaultDir, `${service}.json`)
+    this.filePath = (path.isAbsolute(_filePath))
+      ? _filePath
+      : path.resolve(configDir, _filePath)
   }
 
   async read<T extends AnyObject>(): Promise<T> {


### PR DESCRIPTION
Previously LastRunStore `local` backend and `LocalExporter` output path are resolved from current directory.

Now both output path are resolved from config file directory.

If you exec with `ts-node src/index.ts -c sample/ci_analyzer.yaml`, output files will be created in `sample` directory.