### PR TITLE
Filter runs that after in_progress run

### DIFF
--- a/__tests__/client/circleci_client.test.ts
+++ b/__tests__/client/circleci_client.test.ts
@@ -1,0 +1,34 @@
+import { CircleciClient } from '../../src/client/circleci_client'
+
+const allCompletedRuns = [
+  { build_nums: [2,3], last_build_num: 3, lifecycles: ['finished','finished'] },
+  { build_nums: [4,5], last_build_num: 5, lifecycles: ['finished','finished'] },
+  { build_nums: [6,7], last_build_num: 7, lifecycles: ['finished','finished'] },
+] as any
+
+const hasInprogressRuns = [
+  { build_nums: [2,3], last_build_num: 3, lifecycles: ['finished','finished'] },
+  { build_nums: [4,5], last_build_num: 5, lifecycles: ['finished','running'] },
+  { build_nums: [6,7], last_build_num: 7, lifecycles: ['finished','finished'] },
+] as any
+
+describe('CircleciClient', () => {
+  describe('filterWorkflowRuns', () => {
+    let client: CircleciClient
+    beforeEach(() => {
+      client = new CircleciClient('DUMMY_TOKEN')
+    })
+
+    it('when has not in_pregress runs', async () => {
+      const actual = client.filterWorkflowRuns(allCompletedRuns)
+
+      expect(actual.map((run) => run.last_build_num)).toEqual([3,5,7])
+    })
+
+    it('when has in_pregress runs', async () => {
+      const actual = client.filterWorkflowRuns(hasInprogressRuns)
+
+      expect(actual.map((run) => run.last_build_num)).toEqual([3])
+    })
+  })
+})

--- a/__tests__/client/github_client.test.ts
+++ b/__tests__/client/github_client.test.ts
@@ -1,0 +1,54 @@
+import { GithubClient } from '../../src/client/github_client'
+
+const allCompletedRuns = [
+  { run_number: 2, status: 'completed' },
+  { run_number: 3, status: 'completed' },
+  { run_number: 4, status: 'completed' },
+  { run_number: 5, status: 'completed' },
+  { run_number: 6, status: 'completed' },
+] as any
+
+const hasInprogressRuns = [
+  { run_number: 2, status: 'completed' },
+  { run_number: 3, status: 'completed' },
+  { run_number: 4, status: 'completed' },
+  { run_number: 5, status: 'in_progress' },
+  { run_number: 6, status: 'completed' },
+] as any
+
+describe('GithubClient', () => {
+  describe('filterWorkflowRuns', () => {
+    let client: GithubClient
+    beforeEach(() => {
+      client = new GithubClient('DUMMY_TOKEN')
+    })
+
+    it('when lastRunId is undef and has not in_pregress runs', async () => {
+      const fromId = undefined
+      const actual = client.filterWorkflowRuns(allCompletedRuns, fromId)
+
+      expect(actual.map((run) => run.run_number)).toEqual([2,3,4,5,6])
+    })
+
+    it('when defined lastRunId and has not in_pregress runs', async () => {
+      const fromId = 2
+      const actual = client.filterWorkflowRuns(allCompletedRuns, fromId)
+
+      expect(actual.map((run) => run.run_number)).toEqual([3,4,5,6])
+    })
+
+    it('when lastRunId is undef and has in_pregress runs', async () => {
+      const fromId = undefined
+      const actual = client.filterWorkflowRuns(hasInprogressRuns, fromId)
+
+      expect(actual.map((run) => run.run_number)).toEqual([2,3,4])
+    })
+
+    it('when defined lastRunId and has in_pregress runs', async () => {
+      const fromId = 2
+      const actual = client.filterWorkflowRuns(hasInprogressRuns, fromId)
+
+      expect(actual.map((run) => run.run_number)).toEqual([3,4])
+    })
+  })
+})

--- a/__tests__/client/github_client.test.ts
+++ b/__tests__/client/github_client.test.ts
@@ -24,29 +24,29 @@ describe('GithubClient', () => {
     })
 
     it('when lastRunId is undef and has not in_pregress runs', async () => {
-      const fromId = undefined
-      const actual = client.filterWorkflowRuns(allCompletedRuns, fromId)
+      const lastRunId = undefined
+      const actual = client.filterWorkflowRuns(allCompletedRuns, lastRunId)
 
       expect(actual.map((run) => run.run_number)).toEqual([2,3,4,5,6])
     })
 
     it('when defined lastRunId and has not in_pregress runs', async () => {
-      const fromId = 2
-      const actual = client.filterWorkflowRuns(allCompletedRuns, fromId)
+      const lastRunId = 2
+      const actual = client.filterWorkflowRuns(allCompletedRuns, lastRunId)
 
       expect(actual.map((run) => run.run_number)).toEqual([3,4,5,6])
     })
 
     it('when lastRunId is undef and has in_pregress runs', async () => {
-      const fromId = undefined
-      const actual = client.filterWorkflowRuns(hasInprogressRuns, fromId)
+      const lastRunId = undefined
+      const actual = client.filterWorkflowRuns(hasInprogressRuns, lastRunId)
 
       expect(actual.map((run) => run.run_number)).toEqual([2,3,4])
     })
 
     it('when defined lastRunId and has in_pregress runs', async () => {
-      const fromId = 2
-      const actual = client.filterWorkflowRuns(hasInprogressRuns, fromId)
+      const lastRunId = 2
+      const actual = client.filterWorkflowRuns(hasInprogressRuns, lastRunId)
 
       expect(actual.map((run) => run.run_number)).toEqual([3,4])
     })

--- a/src/client/circleci_client.ts
+++ b/src/client/circleci_client.ts
@@ -100,7 +100,7 @@ export class CircleciClient {
     }
   }
 
-  async fetchWorkflowRuns(owner: string, repo: string, vcsType: string, fromRunId?: number) {
+  async fetchWorkflowRuns(owner: string, repo: string, vcsType: string, lastRunId?: number) {
     // https://circleci.com/api/v1.1/project/:vcs-type/:username/:project?circle-token=:token&limit=20&offset=5&filter=completed
     const res = await this.axios.get( `project/${vcsType}/${owner}/${repo}`, {
       params: {
@@ -114,8 +114,8 @@ export class CircleciClient {
       }
     })
     let recentBuilds = res.data as RecentBuildResponse[]
-    recentBuilds = (fromRunId)
-      ? recentBuilds.filter((build) => build.build_num > fromRunId)
+    recentBuilds = (lastRunId)
+      ? recentBuilds.filter((build) => build.build_num > lastRunId)
       : recentBuilds
 
     // Add dummy workflow data if job is not belong to workflow

--- a/src/client/circleci_client.ts
+++ b/src/client/circleci_client.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from 'axios'
-import { groupBy } from 'lodash'
+import { groupBy, maxBy, max } from 'lodash'
 import { axiosRequestLogger } from './client'
 
 const DEBUG_PER_PAGE = 10
@@ -80,6 +80,7 @@ export type WorkflowRun = {
   vcs_type: string,
   build_nums: number[]
   lifecycles: RecentBuildResponse['lifecycle'][]
+  last_build_num: number
 }
 
 export class CircleciClient {
@@ -138,20 +139,35 @@ export class CircleciClient {
     }), 'workflow_id')
     const workflowRuns: WorkflowRun[] = Object.values(groupedBuilds).map((builds) => {
       const build = builds[0]
+      const build_nums = builds.map((build) => build.build_num)
       return {
         workflow_id: build.workflow_id,
         workflow_name: build.workflow_name,
         reponame: build.reponame,
         username: build.username,
         vcs_type: build.vcs_type,
-        build_nums: builds.map((build) => build.build_num),
-        lifecycles: builds.map((build) => build.lifecycle)
+        build_nums,
+        lifecycles: builds.map((build) => build.lifecycle),
+        last_build_num: max(build_nums)!,
       }
-    }).filter((run) => { // Filter workflow which has build that is not finished yet.
-      return run.lifecycles.every((lifecycle) => lifecycle === 'finished')
     })
 
-    return workflowRuns
+    return this.filterWorkflowRuns(workflowRuns)
+  }
+
+  filterWorkflowRuns (runs: WorkflowRun[]): WorkflowRun[] {
+    const hasNotFinishedRuns = runs.filter((run) => {
+      return !run.lifecycles.every((lifecycle) => lifecycle === 'finished')
+    })
+    const lastInprogress = maxBy(
+      hasNotFinishedRuns,
+      (run) => run.last_build_num,
+    )
+    // Filter to: Id < lastInprogressId
+    runs = (lastInprogress)
+      ? runs.filter((run) => run.last_build_num < lastInprogress.last_build_num)
+      : runs
+    return runs
   }
 
   async fetchJobs(owner: string, repo: string, vcsType: string, runId: number) {

--- a/src/client/github_client.ts
+++ b/src/client/github_client.ts
@@ -20,7 +20,7 @@ export class GithubClient {
   }
 
   // see: https://developer.github.com/v3/actions/workflow-runs/#list-repository-workflow-runs
-  async fetchWorkflowRuns(owner: string, repo: string, fromRunId?: number) {
+  async fetchWorkflowRuns(owner: string, repo: string, lastRunId?: number) {
     const workflows = await this.fetchWorkflows(owner, repo)
     const workflowIdMap = new Map((
       workflows.map((workflow) => [String(workflow.id), workflow.name])
@@ -33,7 +33,7 @@ export class GithubClient {
       // page: 1, // order desc
     })
 
-    const filterdWorkflowRuns = this.filterWorkflowRuns(runs.data.workflow_runs, fromRunId)
+    const filterdWorkflowRuns = this.filterWorkflowRuns(runs.data.workflow_runs, lastRunId)
 
     // Attach workflow name
     return filterdWorkflowRuns.map((run) => {
@@ -45,14 +45,14 @@ export class GithubClient {
     })
   }
 
-  filterWorkflowRuns (runs: WorkflowRunsItem[], fromRunId?: number): WorkflowRunsItem[] {
+  filterWorkflowRuns (runs: WorkflowRunsItem[], lastRunId?: number): WorkflowRunsItem[] {
     const lastInprogress = maxBy(
       runs.filter((run) => run.status as RunStatus === 'in_progress'),
       (run) => run.run_number
     )
-    // Filter to: fromRunId < Id < lastInprogressId
-    runs = (fromRunId)
-      ? runs.filter((run) => run.run_number > fromRunId)
+    // Filter to: lastRunId < Id < lastInprogressId
+    runs = (lastRunId)
+      ? runs.filter((run) => run.run_number > lastRunId)
       : runs
     runs = (lastInprogress)
       ? runs.filter((run) => run.run_number < lastInprogress.run_number)

--- a/src/client/jenkins_client.ts
+++ b/src/client/jenkins_client.ts
@@ -166,7 +166,7 @@ export class JenkinsClient {
     })
   }
 
-  async fetchJobRuns(job: JobResponse, fromRunId?: number) {
+  async fetchJobRuns(job: JobResponse, lastRunId?: number) {
     const res = await this.axios.get(`job/${job.name}/wfapi/runs`, {
       params: {
         fullStages: "true"
@@ -174,8 +174,8 @@ export class JenkinsClient {
     })
 
     const runs = res.data as WfapiRunResponse[]
-    return (fromRunId)
-      ? runs.filter((run) => Number(run.id) > fromRunId)
+    return (lastRunId)
+      ? runs.filter((run) => Number(run.id) > lastRunId)
       : runs
   }
 

--- a/src/runner/circleci_runner.ts
+++ b/src/runner/circleci_runner.ts
@@ -45,8 +45,8 @@ export class CircleciRunner implements Runner {
       const repoReports: WorkflowReport[] = []
 
       try {
-        const fromRunId = this.store.getLastRun(repo.fullname)
-        const workflowRuns = await this.client.fetchWorkflowRuns(repo.owner, repo.repo, repo.vscType, fromRunId)
+        const lastRunId = this.store.getLastRun(repo.fullname)
+        const workflowRuns = await this.client.fetchWorkflowRuns(repo.owner, repo.repo, repo.vscType, lastRunId)
         const tagMap = await this.repoClient.fetchRepositoryTagMap(repo.owner, repo.repo)
 
         for (const workflowRun of workflowRuns) {

--- a/src/runner/github_runner.ts
+++ b/src/runner/github_runner.ts
@@ -43,8 +43,8 @@ export class GithubRunner implements Runner {
       const repoReports: WorkflowReport[] = []
 
       try {
-        const fromRunId = this.store.getLastRun(repo.fullname)
-        const workflowRuns = await this.client.fetchWorkflowRuns(repo.owner, repo.repo, fromRunId)
+        const lastRunId = this.store.getLastRun(repo.fullname)
+        const workflowRuns = await this.client.fetchWorkflowRuns(repo.owner, repo.repo, lastRunId)
         const tagMap = await this.repoClient.fetchRepositoryTagMap(repo.owner, repo.repo)
 
         for (const workflowRun of workflowRuns) {

--- a/src/runner/jenkins_runner.ts
+++ b/src/runner/jenkins_runner.ts
@@ -48,8 +48,8 @@ export class JenkinsRunner implements Runner {
       const jobReports: WorkflowReport[] = []
 
       try {
-        const fromRunId = this.store.getLastRun(job.name)
-        const runs = await this.client.fetchJobRuns(job, fromRunId)
+        const lastRunId = this.store.getLastRun(job.name)
+        const runs = await this.client.fetchJobRuns(job, lastRunId)
 
         for (const run of runs) {
           const build = await this.client.fetchBuild(job, Number(run.id))


### PR DESCRIPTION
Bugfix some case in_progress job never export.

```
build_id: 2, status: finished
build_id: 3, status: in_progress
build_id: 4, status: finished
```

Above case exports `build_id: 2,4` and LastRunId will be detect 4 and store it. Next time fetch runs will start from `build_id: 5`. It means `build_id: 3` never export.

This PR resolve this issue. In above case, exports only `build_id: 2` and ignore `build_id: 3, 4`. Next time fetch runs will start from `build_id: 3`.