### PR TITLE
fix: Bugfix how to detect in_progress run

### DIFF
--- a/__tests__/client/circleci_client.test.ts
+++ b/__tests__/client/circleci_client.test.ts
@@ -9,7 +9,8 @@ const allCompletedRuns = [
 const hasInprogressRuns = [
   { build_nums: [2,3], last_build_num: 3, lifecycles: ['finished','finished'] },
   { build_nums: [4,5], last_build_num: 5, lifecycles: ['finished','running'] },
-  { build_nums: [6,7], last_build_num: 7, lifecycles: ['finished','finished'] },
+  { build_nums: [6,7], last_build_num: 7, lifecycles: ['running','queued'] },
+  { build_nums: [8,9], last_build_num: 9, lifecycles: ['finished','finished'] },
 ] as any
 
 describe('CircleciClient', () => {

--- a/__tests__/client/github_client.test.ts
+++ b/__tests__/client/github_client.test.ts
@@ -11,7 +11,7 @@ const allCompletedRuns = [
 const hasInprogressRuns = [
   { run_number: 2, status: 'completed' },
   { run_number: 3, status: 'completed' },
-  { run_number: 4, status: 'completed' },
+  { run_number: 4, status: 'in_progress' },
   { run_number: 5, status: 'in_progress' },
   { run_number: 6, status: 'completed' },
 ] as any
@@ -41,14 +41,14 @@ describe('GithubClient', () => {
       const lastRunId = undefined
       const actual = client.filterWorkflowRuns(hasInprogressRuns, lastRunId)
 
-      expect(actual.map((run) => run.run_number)).toEqual([2,3,4])
+      expect(actual.map((run) => run.run_number)).toEqual([2,3])
     })
 
     it('when defined lastRunId and has in_pregress runs', async () => {
       const lastRunId = 2
       const actual = client.filterWorkflowRuns(hasInprogressRuns, lastRunId)
 
-      expect(actual.map((run) => run.run_number)).toEqual([3,4])
+      expect(actual.map((run) => run.run_number)).toEqual([3])
     })
   })
 })

--- a/__tests__/client/jenkins_client.test.ts
+++ b/__tests__/client/jenkins_client.test.ts
@@ -40,16 +40,8 @@ describe('JenkinsClient', () => {
     const hasInprogressRuns = [
       { id: '2', status: 'SUCCESS' },
       { id: '3', status: 'FAILED' },
-      { id: '4', status: 'ABORTED' },
+      { id: '4', status: 'IN_PROGRESS' },
       { id: '5', status: 'IN_PROGRESS' },
-      { id: '6', status: 'SUCCESS' },
-    ] as any
-
-    const hasNotexecutedRuns = [
-      { id: '2', status: 'SUCCESS' },
-      { id: '3', status: 'FAILED' },
-      { id: '4', status: 'ABORTED' },
-      { id: '5', status: 'NOT_EXECUTED' },
       { id: '6', status: 'SUCCESS' },
     ] as any
 
@@ -76,14 +68,14 @@ describe('JenkinsClient', () => {
       const lastRunId = undefined
       const actual = client.filterJobRuns(hasInprogressRuns, lastRunId)
 
-      expect(actual.map((run) => run.id)).toEqual(['2','3','4'])
+      expect(actual.map((run) => run.id)).toEqual(['2','3'])
     })
 
     it('when defined lastRunId and has in_pregress runs', async () => {
       const lastRunId = 2
       const actual = client.filterJobRuns(hasInprogressRuns, lastRunId)
 
-      expect(actual.map((run) => run.id)).toEqual(['3','4'])
+      expect(actual.map((run) => run.id)).toEqual(['3'])
     })
   })
 })

--- a/src/client/circleci_client.ts
+++ b/src/client/circleci_client.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from 'axios'
-import { groupBy, maxBy, max } from 'lodash'
+import { groupBy, max, minBy } from 'lodash'
 import { axiosRequestLogger } from './client'
 
 const DEBUG_PER_PAGE = 10
@@ -155,17 +155,17 @@ export class CircleciClient {
     return this.filterWorkflowRuns(workflowRuns)
   }
 
+  // Filter to: Id < firstInprogressId
   filterWorkflowRuns (runs: WorkflowRun[]): WorkflowRun[] {
     const hasNotFinishedRuns = runs.filter((run) => {
       return !run.lifecycles.every((lifecycle) => lifecycle === 'finished')
     })
-    const lastInprogress = maxBy(
+    const firstInprogress = minBy(
       hasNotFinishedRuns,
       (run) => run.last_build_num,
     )
-    // Filter to: Id < lastInprogressId
-    runs = (lastInprogress)
-      ? runs.filter((run) => run.last_build_num < lastInprogress.last_build_num)
+    runs = (firstInprogress)
+      ? runs.filter((run) => run.last_build_num < firstInprogress.last_build_num)
       : runs
     return runs
   }

--- a/src/client/github_client.ts
+++ b/src/client/github_client.ts
@@ -1,5 +1,5 @@
 import { Octokit, RestEndpointMethodTypes } from "@octokit/rest";
-import { maxBy } from "lodash";
+import { minBy } from "lodash";
 
 // Oktokit document: https://octokit.github.io/rest.js/v17#actions
 
@@ -45,17 +45,17 @@ export class GithubClient {
     })
   }
 
+  // Filter to: lastRunId < Id < firstInprogressId
   filterWorkflowRuns (runs: WorkflowRunsItem[], lastRunId?: number): WorkflowRunsItem[] {
-    const lastInprogress = maxBy(
-      runs.filter((run) => run.status as RunStatus === 'in_progress'),
-      (run) => run.run_number
-    )
-    // Filter to: lastRunId < Id < lastInprogressId
     runs = (lastRunId)
       ? runs.filter((run) => run.run_number > lastRunId)
       : runs
-    runs = (lastInprogress)
-      ? runs.filter((run) => run.run_number < lastInprogress.run_number)
+    const firstInprogress = minBy(
+      runs.filter((run) => run.status as RunStatus === 'in_progress'),
+      (run) => run.run_number
+    )
+    runs = (firstInprogress)
+      ? runs.filter((run) => run.run_number < firstInprogress.run_number)
       : runs
     return runs
   }

--- a/src/client/jenkins_client.ts
+++ b/src/client/jenkins_client.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from 'axios'
 import { axiosRequestLogger } from './client'
-import { maxBy } from 'lodash'
+import { minBy } from 'lodash'
 
 // ref: https://github.com/jenkinsci/pipeline-stage-view-plugin/blob/master/rest-api/src/main/java/com/cloudbees/workflow/rest/external/StatusExt.java
 export type JenkinsStatus = 'SUCCESS' | 'FAILED' | 'ABORTED' | 'NOT_EXECUTED' | 'IN_PROGRESS' | 'PAUSED_PENDING_INPUT' | 'UNSTABLE'
@@ -178,17 +178,17 @@ export class JenkinsClient {
     return this.filterJobRuns(runs, lastRunId)
   }
 
+  // Filter to: lastRunId < Id < firstInprogressId
   filterJobRuns (runs: WfapiRunResponse[], lastRunId?: number): WfapiRunResponse[] {
-    const lastInprogress = maxBy(
-      runs.filter((run) => run.status === 'IN_PROGRESS' || run.status === 'NOT_EXECUTED' ),
-      (run) => Number(run.id)
-    )
-    // Filter to: lastRunId < Id < lastInprogressId
     runs = (lastRunId)
       ? runs.filter((run) => Number(run.id) > lastRunId)
       : runs
-    runs = (lastInprogress)
-      ? runs.filter((run) => Number(run.id) < Number(lastInprogress.id))
+    const firstInprogress = minBy(
+      runs.filter((run) => run.status === 'IN_PROGRESS' ),
+      (run) => Number(run.id)
+    )
+    runs = (firstInprogress)
+      ? runs.filter((run) => Number(run.id) < Number(firstInprogress.id))
       : runs
     return runs
   }


### PR DESCRIPTION
Fix bug created by #13

- Jenkins `NOT_EXECUTED` status is not mean 'in progress'
- Filter after in_progress run algorithm is incorrect. When there are multiple in_progress runs.
  - See fixed test case.