### PR TITLE
Improve docker run command with volume mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN npm run clean && npm run build
 
 # Setup production stage
 FROM node:12-alpine
-WORKDIR /app
+WORKDIR /ci_analyzer
 
 COPY package*.json ./
 RUN npm install --production
@@ -18,4 +18,8 @@ RUN npm install --production
 COPY . .
 COPY --from=ts-builder /build/dist ./dist
 
-ENTRYPOINT [ "npm", "run", "start", "--" ]
+# Resolve nodejs pid=1 problem
+RUN apk add --no-cache tini
+ENTRYPOINT [ "/sbin/tini", "--", "node", "/ci_analyzer/dist/index.js" ]
+
+WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ RUN npm install --production
 COPY . .
 COPY --from=ts-builder /build/dist ./dist
 
+# Make "ci_analyzer" command alias
+RUN cd dist && ln -s index.js ci_analyzer && chmod +x ci_analyzer
+ENV PATH=/ci_analyzer/dist:$PATH
+
 # Resolve nodejs pid=1 problem
 RUN apk add --no-cache tini
 ENTRYPOINT [ "/sbin/tini", "--", "node", "/ci_analyzer/dist/index.js" ]

--- a/sample/cron.jenkinsfile
+++ b/sample/cron.jenkinsfile
@@ -12,22 +12,17 @@ pipeline {
       }
       steps {
         sh """
-          mkdir -p output
-          mkdir -p .ci_analyzer
-        """
-        sh """
           docker pull kesin/ci_analyzer:latest
           docker run \
-            --mount type=bind,src=${CONFIG_FILE_PATH},dst=/app/ci_analyzer.yaml \
-            --mount type=bind,src=${WORKSPACE}/output,dst=/app/output \
-            --mount type=bind,src=${WORKSPACE}/.ci_analyzer,dst=/app/.ci_analyzer \
-            --mount type=bind,src=${SERVICE_ACCOUNT},dst=/app/service_account.json \
+            --mount type=bind,src=${WORKSPACE},dst=/app/ \
+            --mount type=bind,src=${SERVICE_ACCOUNT},dst=/service_account.json \
+            --mount type=bind,src=${CONFIG_FILE_PATH},dst=/ci_analyzer.yaml \
             -e GITHUB_TOKEN=${GITHUB_TOKEN} \
             -e CIRCLECI_TOKEN=${CIRCLECI_TOKEN} \
             -e JENKINS_USER=${JENKINS_USR} \
             -e JENKINS_TOKEN=${JENKINS_PSW} \
-            -e GOOGLE_APPLICATION_CREDENTIALS=/app/service_account.json \
-            kesin/ci_analyzer:latest
+            -e GOOGLE_APPLICATION_CREDENTIALS=/service_account.json \
+            kesin/ci_analyzer:latest -c /ci_analyzer.yaml
         """
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import yargs from 'yargs'
 import { loadConfig } from './config/config'
 import { CompositRunner } from './runner/runner'


### PR DESCRIPTION
Previously, we have to mount each file or directory that will be load or create by CIAnalyzer.
Previous `docker run` options are Like this.

```
--mount type=bind,src=${CONFIG_FILE_PATH},dst=/app/ci_analyzer.yaml \
--mount type=bind,src=${WORKSPACE}/output,dst=/app/output \
--mount type=bind,src=${WORKSPACE}/.ci_analyzer,dst=/app/.ci_analyzer \
--mount type=bind,src=${SERVICE_ACCOUNT},dst=/app/service_account.json \
```

This pull-req reduce mount file or directory that need for CIAanalyzer. We will need just only mount current directory (pwd) to `/app`.