### PR TITLE
fix: Validate CircleCI step end_time

### DIFF
--- a/src/analyzer/circleci_analyzer.ts
+++ b/src/analyzer/circleci_analyzer.ts
@@ -73,7 +73,9 @@ export class CircleciAnalyzer implements Analyzer {
       const stepReports: StepReport[] = job.steps.map((step) => {
         const action = first(step.actions)!
         const startedAt = new Date(action.start_time)
-        const completedAt = new Date(action.end_time)
+        // NOTE: Sometimes action.end_time will be broken, so it should be replaced when it's value is invalid.
+        const validatedEndTime = action.end_time ?? action.start_time
+        const completedAt = new Date(validatedEndTime)
         // step
         return {
           name: action.name,

--- a/src/client/circleci_client.ts
+++ b/src/client/circleci_client.ts
@@ -61,10 +61,10 @@ type Steps = {
   actions: {
     name: string
     status: CircleciStatus
-    end_time: string,
+    end_time: string | null, // Sometimes step log will be broken and return null
     start_time: string,
     step: number,
-    run_time_millis: number,
+    run_time_millis: number | null, // Sometimes step log will be broken and return null
   }[]
 }
 export type SingleBuildResponse = RecentBuildResponse & {


### PR DESCRIPTION
Sometimes CircleCI API returns a response that has invalid step data.

Invalid step is like this

```
actions: [{
  "status": "running",
  "end_time": null,
  "run_time_millis": null
}] 
```

even build lifecycle is "finished".
If CircleciAnalyzer makes report from a build that includes invalid step, `completedAt` will be translated 1970-01-01. As a result, stepDurationSec will be a very large minus value (around -1.59E9).