### PR TITLE
Support creating test report from testsuite tag root XML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6016,13 +6016,33 @@
       }
     },
     "junit2json": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/junit2json/-/junit2json-1.0.2.tgz",
-      "integrity": "sha512-nN93EdpW3y1sIHg2ngUH7gG17YmkY+aANM8qqwuHyLIc7eM8TRHhoh6b+lRGP1aTU1SinM7eF6YXxFwqBiE3XA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/junit2json/-/junit2json-2.0.0.tgz",
+      "integrity": "sha512-MM5iUDF7+oN0FW4dMIjxFmLPvhBUOAUkcMb5ownFk4e7wVFnaWf5xgFZ3+DsDiPJGsaTGc6dMCRxeL1dP8oC2g==",
       "requires": {
         "@types/xml2js": "0.4.5",
         "xml2js": "0.4.23",
-        "yargs": "15.3.1"
+        "yargs": "15.4.1"
+      },
+      "dependencies": {
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        }
       }
     },
     "jwa": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "axios": "0.19.2",
     "dayjs": "1.8.27",
     "js-yaml": "3.13.1",
-    "junit2json": "1.0.2",
+    "junit2json": "2.0.0",
     "lodash": "4.17.15",
     "minimatch": "3.0.4",
     "yargs": "15.3.1"

--- a/src/analyzer/github_analyzer.ts
+++ b/src/analyzer/github_analyzer.ts
@@ -153,7 +153,17 @@ export class GithubAnalyzer implements Analyzer {
     for (const artifact of junitArtifacts) {
       const xmlString = Buffer.from(artifact.data).toString('utf8')
       try {
-        const testSuites = await parse(xmlString)
+        const result = await parse(xmlString)
+        const testSuites = ('testsuite' in result) ? result : {
+          // Fill in testsuites property with testsuit values.
+          testsuite: [result],
+          name: workflowId,
+          time: result.time,
+          tests: result.tests,
+          failures: result.failures,
+          errors: result.errors,
+        }
+
         testReports.push({
           workflowId,
           workflowRunId,

--- a/src/analyzer/jenkins_analyzer.ts
+++ b/src/analyzer/jenkins_analyzer.ts
@@ -143,9 +143,19 @@ export class JenkinsAnalyzer implements Analyzer {
 
     const testReports: TestReport[] = []
     for (const artifact of junitArtifacts) {
+      const xmlString = Buffer.from(artifact.data).toString('utf8')
       try {
-        const xmlString = Buffer.from(artifact.data).toString('utf8')
-        const testSuites = await parse(xmlString)
+        const result = await parse(xmlString)
+        const testSuites = ('testsuite' in result) ? result : {
+          // Fill in testsuites property with testsuit values.
+          testsuite: [result],
+          name: workflowId,
+          time: result.time,
+          tests: result.tests,
+          failures: result.failures,
+          errors: result.errors,
+        }
+
         testReports.push({
           workflowId,
           workflowRunId,


### PR DESCRIPTION
Some language ecosystem test report using `<testsuite></testsuite>` as root tag for JUnit XML. (e.g. Android test report)
If CIAnalyzer collects this type of JUnit XML, it's complete some properties and create test reports as same as `<testsuites></testsuites>` root tag XML.