### PR TITLE
BigqueryExporter support loading TestReport

### DIFF
--- a/__tests__/exporter/bigquery_exporter.test.ts
+++ b/__tests__/exporter/bigquery_exporter.test.ts
@@ -8,12 +8,14 @@ const bigqueryMock = {
 }
 
 describe('BigqueryExporter', () => {
+  const workflowTable = 'workflow'
+  const testReportTable = 'test_report'
   const config: BigqueryExporterConfig = {
     project: 'project',
     dataset: 'dataset',
     reports: [
-      { name: 'workflow', table: 'workflow' },
-      { name: 'test_report', table: 'test_report' },
+      { name: 'workflow', table: workflowTable },
+      { name: 'test_report', table: testReportTable },
     ]
   }
   describe('new', () => {
@@ -52,7 +54,7 @@ describe('BigqueryExporter', () => {
     })
   })
 
-  describe('exportWorkflowReports', () => {
+  describe('export', () => {
     const report = [{}]
     let exporter: BigqueryExporter
     beforeEach(() => {
@@ -60,10 +62,18 @@ describe('BigqueryExporter', () => {
       exporter.bigquery = bigqueryMock as any
     })
 
-    it('should finish with no error', async () => {
+    it('exportWorkflowReports load to `workflow` table', async () => {
       await exporter.exportWorkflowReports(report as any)
 
       expect(bigqueryMock.load.mock.calls.length).toBe(1)
+      expect(bigqueryMock.table.mock.calls[0][0]).toBe(workflowTable)
+    })
+
+    it('exportTestReports load to `test_report` table', async () => {
+      await exporter.exportTestReports(report as any)
+
+      expect(bigqueryMock.load.mock.calls.length).toBe(1)
+      expect(bigqueryMock.table.mock.calls[0][0]).toBe(testReportTable)
     })
   })
 })

--- a/__tests__/exporter/bigquery_exporter.test.ts
+++ b/__tests__/exporter/bigquery_exporter.test.ts
@@ -1,5 +1,11 @@
 import { BigqueryExporter } from '../../src/exporter/bigquery_exporter'
 
+const bigqueryMock = {
+  dataset: jest.fn().mockReturnThis(),
+  table: jest.fn().mockReturnThis(),
+  load: jest.fn(async () => [{}]) // return success 'results' stub
+}
+
 describe('BigqueryExporter', () => {
   describe('new', () => {
     it('should not throw when project, dataset, table are not undefined', async () => {
@@ -20,6 +26,21 @@ describe('BigqueryExporter', () => {
       expect(() => {
         const _exporter = new BigqueryExporter('project', 'dataset', undefined )
       }).toThrow()
+    })
+  })
+
+  describe('exportWorkflowReports', () => {
+    const report = [{}]
+    let exporter: BigqueryExporter
+    beforeEach(() => {
+      exporter = new BigqueryExporter('project', 'dataset', 'table' )
+      exporter.bigquery = bigqueryMock as any
+    })
+
+    it('should finish with no error', async () => {
+      await exporter.exportWorkflowReports(report as any)
+
+      expect(bigqueryMock.load.mock.calls.length).toBe(1)
     })
   })
 })

--- a/__tests__/exporter/bigquery_exporter.test.ts
+++ b/__tests__/exporter/bigquery_exporter.test.ts
@@ -1,4 +1,5 @@
 import { BigqueryExporter } from '../../src/exporter/bigquery_exporter'
+import { BigqueryExporterConfig } from '../../src/config/config'
 
 const bigqueryMock = {
   dataset: jest.fn().mockReturnThis(),
@@ -7,24 +8,46 @@ const bigqueryMock = {
 }
 
 describe('BigqueryExporter', () => {
+  const config: BigqueryExporterConfig = {
+    project: 'project',
+    dataset: 'dataset',
+    reports: [
+      { name: 'workflow', table: 'workflow' },
+      { name: 'test_report', table: 'test_report' },
+    ]
+  }
   describe('new', () => {
-    it('should not throw when project, dataset, table are not undefined', async () => {
+    it('should not throw when any params are not undefined', async () => {
       expect(() => {
-        const _exporter = new BigqueryExporter('project', 'dataset', 'table' )
+        new BigqueryExporter(config)
       })
     })
 
-    it('should throw when some of project, dataset, table is undefined', async () => {
+    it('should throw when project is undefined', async () => {
+      const _config = { ...config, project: undefined }
       expect(() => {
-        const _exporter = new BigqueryExporter(undefined, 'dataset', 'table' )
+        new BigqueryExporter(_config)
       }).toThrow()
+    })
 
+    it('should throw when dataset is undefined', async () => {
+      const _config = { ...config, dataset: undefined }
       expect(() => {
-        const _exporter = new BigqueryExporter('project', undefined, 'table' )
+        new BigqueryExporter(_config)
       }).toThrow()
+    })
 
+    it('should throw when workflow table is undefined', async () => {
+      const _config = { ...config, reports: [{ name: 'workflow', table: 'workflow'}] }
       expect(() => {
-        const _exporter = new BigqueryExporter('project', 'dataset', undefined )
+        new BigqueryExporter(_config as any)
+      }).toThrow()
+    })
+
+    it('should throw when test_report table is undefined', async () => {
+      const _config = { ...config, reports: [{ name: 'test_report', table: 'test_report'}] }
+      expect(() => {
+        new BigqueryExporter(_config as any)
       }).toThrow()
     })
   })
@@ -33,7 +56,7 @@ describe('BigqueryExporter', () => {
     const report = [{}]
     let exporter: BigqueryExporter
     beforeEach(() => {
-      exporter = new BigqueryExporter('project', 'dataset', 'table' )
+      exporter = new BigqueryExporter(config)
       exporter.bigquery = bigqueryMock as any
     })
 

--- a/__tests__/exporter/local_exporter.test.ts
+++ b/__tests__/exporter/local_exporter.test.ts
@@ -1,15 +1,37 @@
 import { LocalExporter } from '../../src/exporter/local_exporter'
 import path from 'path'
+import { LocalExporterConfig } from '../../src/config/config'
 
 describe('LocalExporter', () => {
   describe('new', () => {
     it('should all property set with default parameter when options is null', async () => {
+      const config: LocalExporterConfig = {}
       const configDir = __dirname
-      // Argument type does not accept null, but some case js-yaml returns 'null' as exporter options
-      const exporter = new LocalExporter('github', configDir, null as any )
+      const exporter = new LocalExporter('github', configDir, config )
 
       expect(exporter.outDir).toEqual(path.resolve(configDir, 'output'))
       expect(exporter.formatter).toEqual(exporter.formatJson)
+    })
+
+    it('should outDir is set when it given by config', async () => {
+      const expectedDir = 'test_output'
+      const config: LocalExporterConfig = {
+        outDir: expectedDir
+      }
+      const configDir = __dirname
+      const exporter = new LocalExporter('github', configDir, config )
+
+      expect(exporter.outDir).toEqual(path.resolve(configDir, expectedDir))
+    })
+
+    it('should formatter is set when it given by config', async () => {
+      const config: LocalExporterConfig = {
+        format: 'json_lines'
+      }
+      const configDir = __dirname
+      const exporter = new LocalExporter('github', configDir, config )
+
+      expect(exporter.formatter).toEqual(exporter.formatJsonLines)
     })
   })
 })

--- a/ci_analyzer.yaml
+++ b/ci_analyzer.yaml
@@ -13,7 +13,11 @@ github:
     bigquery:
       project: common-dev-242504
       dataset: ci_analyzer
-      table: bigquery_exporter
+      reports:
+        - name: workflow
+          table: bigquery_exporter
+        - name: test_report
+          table: test_report
       maxBadRecords: 0 # (Optional) default: 0. If set > 0, skip bad record. This option should only be used for workaround.
   lastRunStore:
     backend: local # default: local

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,4 +12,5 @@ module.exports = {
     // 'jest-junit'
   ],
   testEnvironment: 'node',
+  clearMocks: true,
 };

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -19,9 +19,23 @@ export type CommonConfig = {
 }
 
 export type ExporterConfig = {
-  [exporterName: string]: {
-    [options: string]: any
-  }
+  local: LocalExporterConfig
+  bigquery: BigqueryExporterConfig
+}
+
+export type LocalExporterConfig = {
+  outDir: string
+  format: 'json' | 'json_lines'
+}
+
+export type BigqueryExporterConfig = {
+  project?: string
+  dataset?: string
+  reports?: {
+    name: 'workflow' | 'test_report'
+    table: string
+  }[]
+  maxBadRecords?: number
 }
 
 export type LastRunStoreConfig = {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -24,8 +24,8 @@ export type ExporterConfig = {
 }
 
 export type LocalExporterConfig = {
-  outDir: string
-  format: 'json' | 'json_lines'
+  outDir?: string
+  format?: 'json' | 'json_lines'
 }
 
 export type BigqueryExporterConfig = {

--- a/src/exporter/exporter.ts
+++ b/src/exporter/exporter.ts
@@ -12,7 +12,7 @@ export class CompositExporter implements Exporter {
   exporters: (Exporter | undefined)[]
   constructor(service: string, configDir: string, config?: ExporterConfig) {
     if (!config) {
-      this.exporters = [ new LocalExporter(service, configDir) ]
+      this.exporters = [ new LocalExporter(service, configDir, {}) ]
       return
     }
 
@@ -21,7 +21,7 @@ export class CompositExporter implements Exporter {
       switch (exporter) {
         case 'local':
           _config = config['local']
-          return new LocalExporter(service, configDir, { outDir: _config.outDir, format: _config.format })
+          return new LocalExporter(service, configDir, _config)
         case 'bigquery':
           _config = config['bigquery']
           return new BigqueryExporter(_config)

--- a/src/exporter/exporter.ts
+++ b/src/exporter/exporter.ts
@@ -1,6 +1,6 @@
 import { LocalExporter } from "./local_exporter";
 import { WorkflowReport, TestReport } from "../analyzer/analyzer";
-import { ExporterConfig } from "../config/config";
+import { ExporterConfig, LocalExporterConfig, BigqueryExporterConfig } from "../config/config";
 import { BigqueryExporter } from "./bigquery_exporter";
 
 export interface Exporter {
@@ -16,12 +16,15 @@ export class CompositExporter implements Exporter {
       return
     }
 
-    this.exporters = Object.entries(config).map(([exporter, options]) => {
+    this.exporters = Object.keys(config).map((exporter) => {
+      let _config: LocalExporterConfig | BigqueryExporterConfig
       switch (exporter) {
         case 'local':
-          return new LocalExporter(service, configDir, { outDir: options.outDir, format: options.format })
+          _config = config['local']
+          return new LocalExporter(service, configDir, { outDir: _config.outDir, format: _config.format })
         case 'bigquery':
-          return new BigqueryExporter(options.project, options.dataset, options.table, { maxBadRecords: options.maxBadRecords })
+          _config = config['bigquery']
+          return new BigqueryExporter(_config)
         default:
           return undefined
       }

--- a/src/exporter/local_exporter.ts
+++ b/src/exporter/local_exporter.ts
@@ -3,8 +3,8 @@ import fs from "fs"
 import dayjs from 'dayjs'
 import { WorkflowReport, TestReport } from "../analyzer/analyzer"
 import { Exporter } from "./exporter"
+import { LocalExporterConfig } from "../config/config"
 
-type Format = 'json' | 'json_lines'
 const defaultOutDir = 'output'
 
 export class LocalExporter implements Exporter {
@@ -14,14 +14,14 @@ export class LocalExporter implements Exporter {
   constructor(
     service: string,
     configDir: string,
-    options?: { outDir?: string, format?: Format }
+    config: LocalExporterConfig,
   ) {
     this.service = service
-    const _outDir = options?.outDir ?? defaultOutDir
+    const _outDir = config.outDir ?? defaultOutDir
     this.outDir = (path.isAbsolute(_outDir))
       ? _outDir
       : path.resolve(configDir, _outDir)
-    const format = options?.format ?? 'json'
+    const format = config?.format ?? 'json'
     this.formatter = (format === 'json') ? this.formatJson : this.formatJsonLines
   }
 


### PR DESCRIPTION
CIAnalyzer support loading TestReport to BigQuery now.

**BREAKING CHANGES**: Change config file exporter.bigquery schama.
`exporter.bigquery.table` is deprecated. Please fix to `exporter.bigquery.reports`.

```yaml
    bigquery:
      project: GCP_PROJECT
      dataset: BIGQUERY_DATASET
      reports:
        - name: workflow
          table: WORKFLOW_TABLE
        - name: test_report
          table: TESTREPORT_TABLE
```
