### PR TITLE
Feature/bump types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1417,15 +1417,15 @@
       }
     },
     "@types/js-yaml": {
-      "version": "3.12.4",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.4.tgz",
-      "integrity": "sha512-fYMgzN+9e28R81weVN49inn/u798ruU91En1ZnGvSZzCRc5jXx9B2EDhlRaWmcO1RIxFHL8AajRXzxDuJu93+A==",
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.5.tgz",
+      "integrity": "sha512-JCcp6J0GV66Y4ZMDAQCXot4xprYB+Zfd3meK9+INSJeVZwJmHAW30BBEEkPzXswMXuiyReUGOP3GxrADc9wPww==",
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.151",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.151.tgz",
-      "integrity": "sha512-Zst90IcBX5wnwSu7CAS0vvJkTjTELY4ssKbHiTnGcJgi170uiS8yQDdc3v6S77bRqYQIN1App5a1Pc2lceE5/g==",
+      "version": "4.14.159",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.159.tgz",
+      "integrity": "sha512-gF7A72f7WQN33DpqOWw9geApQPh4M3PxluMtaHxWHXEGSN12/WbcEk/eNSqWNQcQhF66VSZ06vCF94CrHwXJDg==",
       "dev": true
     },
     "@types/minimatch": {
@@ -1441,9 +1441,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.1.tgz",
-      "integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA=="
+      "version": "14.0.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
+      "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
   "devDependencies": {
     "@types/adm-zip": "0.4.33",
     "@types/jest": "25.2.2",
-    "@types/js-yaml": "3.12.4",
-    "@types/lodash": "4.14.151",
-    "@types/node": "14.0.1",
+    "@types/js-yaml": "3.12.5",
+    "@types/lodash": "4.14.159",
+    "@types/node": "14.0.27",
     "@types/yargs": "15.0.5",
     "codecov": "3.7.2",
     "jest": "26.0.1",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -54,12 +54,15 @@ export const loadConfig = (configPath?: string): YamlConfig => {
   configPath = configPath ?? defaultPath
 
   const config = yaml.safeLoad(fs.readFileSync(configPath, 'utf8'))
-  config.configDir = path.dirname(path.resolve(configPath))
+  if (!config || typeof config !== "object") throw `Failed to load ${configPath} or config is not object`
 
   if (process.env['CI_ANALYZER_DEBUG']) {
     console.debug('Parsed config file:')
     console.debug(JSON.stringify(config, null, 2))
   }
 
-  return config as YamlConfig
+  return {
+    ...config,
+    ...{ configDir: path.dirname(path.resolve(configPath)) }
+  } as YamlConfig
 }


### PR DESCRIPTION
fix: #49 

Since update `@types/js-yaml`, `yaml.safeLoad` return union type `object | string | undefined` and it breaks our code type checking.
To fix this problem, add more safety type checking code.