### PR TITLE
fix: Set default param when exporter.local is null

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -19,8 +19,8 @@ export type CommonConfig = {
 }
 
 export type ExporterConfig = {
-  local: LocalExporterConfig
-  bigquery: BigqueryExporterConfig
+  local: LocalExporterConfig | null
+  bigquery: BigqueryExporterConfig | null
 }
 
 export type LocalExporterConfig = {

--- a/src/exporter/exporter.ts
+++ b/src/exporter/exporter.ts
@@ -20,10 +20,10 @@ export class CompositExporter implements Exporter {
       let _config: LocalExporterConfig | BigqueryExporterConfig
       switch (exporter) {
         case 'local':
-          _config = config['local']
+          _config = config['local'] ?? {}
           return new LocalExporter(service, configDir, _config)
         case 'bigquery':
-          _config = config['bigquery']
+          _config = config['bigquery'] ?? {}
           return new BigqueryExporter(_config)
         default:
           return undefined


### PR DESCRIPTION
Fix bug that throw exception when exporter.local is null.