### PR TITLE
Improve Jenkins CI again

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,44 +1,40 @@
 pipeline {
-  agent none
+  agent any
   options {
     timestamps()
     ansiColor('xterm')
     timeout(time: 20, unit: 'MINUTES') 
   }
   stages {
-    stage('Parallel Stage') {
-      parallel {
-        stage('lint') {
-          agent {
-            docker {
-              image 'node:lts'
-              args '-u root:sudo'
-            }
-          }
-          steps {
-            checkout scm
-            sh "npm ci"
-            sh "npm run lint"
-          }
+    stage('lint') {
+      agent {
+        docker {
+          image 'node:lts'
+          args '-u root:sudo'
         }
-        stage('build and test') {
-          agent {
-            docker {
-              image 'node:lts'
-              args '-u root:sudo'
-            }
-          }
-          steps {
-            checkout scm
-            sh "npm ci"
-            sh "npm run build"
-            sh "npm run test:ci"
-          }
-          post {
-            always {
-              archiveArtifacts artifacts: 'junit/*.xml'
-            }
-          }
+      }
+      steps {
+        checkout scm
+        sh "npm ci"
+        sh "npm run lint"
+      }
+    }
+    stage('build and test') {
+      agent {
+        docker {
+          image 'node:lts'
+          args '-u root:sudo'
+        }
+      }
+      steps {
+        checkout scm
+        sh "npm ci"
+        sh "npm run build"
+        sh "npm run test:ci"
+      }
+      post {
+        always {
+          archiveArtifacts artifacts: 'junit/*.xml'
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,24 +1,24 @@
 pipeline {
-  agent any
+  agent none
   options {
     timestamps()
     ansiColor('xterm')
     timeout(time: 20, unit: 'MINUTES') 
   }
   stages {
-    stage('lint') {
-      agent {
-        docker {
-          image 'node:lts'
-          args '-u root:sudo'
-        }
-      }
-      steps {
-        checkout scm
-        sh "npm ci"
-        sh "npm run lint"
-      }
-    }
+    // stage('lint') {
+    //   agent {
+    //     docker {
+    //       image 'node:lts'
+    //       args '-u root:sudo'
+    //     }
+    //   }
+    //   steps {
+    //     checkout scm
+    //     sh "npm ci"
+    //     sh "npm run lint"
+    //   }
+    // }
     stage('build and test') {
       agent {
         docker {


### PR DESCRIPTION
- Revert parallel run. On my machine, the execution time has been increased by parallel run.
- Skip lint stage. `npm run lint` has not been implemented yet but lint stage waste of time with `npm ci`.