### PR TITLE
Improve some features about parallel execution

### DIFF
--- a/src/custom_report_collection.ts
+++ b/src/custom_report_collection.ts
@@ -42,7 +42,7 @@ export const createCustomReportCollection = async (workflowReport: WorkflowRepor
         createdAt: workflowReport.createdAt,
         ...data
       } as CustomReport
-    }).filter((report) => report !== undefined) as CustomReport[]
+    }).filter((report): report is CustomReport => report !== undefined)
 
     reportCollection.set(reportName, reports)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,11 @@ const main = async () => {
   const yamlConfig = loadConfig(argv.c)
 
   const runner = new CompositRunner(yamlConfig)
-  await runner.run()
+  const result = await runner.run()
+
+  if (result.isFailure()) {
+    console.info('Some runners return error!')
+    process.exitCode = 1
+  }
 }
 main()

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ const main = async () => {
   const result = await runner.run()
 
   if (result.isFailure()) {
-    console.info('Some runners return error!')
+    console.error(result.value)
     process.exitCode = 1
   }
 }

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,0 +1,17 @@
+export type Result<T, E> = Success<T, E> | Failure<T, E>
+export const success = <T, E>(value?: T): Success<T | undefined, E> => new Success(value)
+export const failure = <T, E>(value: E): Failure<T, E> => new Failure(value)
+
+class Success<T, E> {
+  type = 'success' as const
+  constructor(readonly value: T) {}
+  isSuccess(): this is Success<T, E> { return true }
+  isFailure(): this is Failure<T, E> { return false }
+}
+
+class Failure<T, E> {
+  type = 'failure' as const
+  constructor(readonly value: E) {}
+  isSuccess(): this is Success<T, E> { return false }
+  isFailure(): this is Failure<T, E> { return true }
+}

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -8,7 +8,7 @@ export interface Runner {
 }
 
 export class CompositRunner implements Runner {
-  runners: (Runner | undefined)[]
+  runners: Runner[]
   constructor(public config: YamlConfig) {
     this.runners = Object.keys(config).map((service) => {
       switch (service) {
@@ -21,12 +21,12 @@ export class CompositRunner implements Runner {
         default:
           return undefined
       }
-    })
+    }).filter((runner): runner is NonNullable<typeof runner> => runner !== undefined)
   }
 
   async run () {
     await Promise.all(
-      this.runners.map((runner) => runner?.run())
+      this.runners.map((runner) => runner.run())
     )
   }
 }

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -2,9 +2,10 @@ import { YamlConfig } from "../config/config";
 import { GithubRunner } from "./github_runner";
 import { CircleciRunner } from "./circleci_runner";
 import { JenkinsRunner } from "./jenkins_runner";
+import { failure, Result, success } from "../result";
 
 export interface Runner {
-  run (): Promise<void>
+  run (): Promise<Result<void, Error>>
 }
 
 export class CompositRunner implements Runner {
@@ -24,9 +25,17 @@ export class CompositRunner implements Runner {
     }).filter((runner): runner is NonNullable<typeof runner> => runner !== undefined)
   }
 
-  async run () {
-    await Promise.all(
+  async run(): Promise<Result<void, Error>> {
+    const results = await Promise.all(
       this.runners.map((runner) => runner.run())
     )
+
+    const errorResults = results.filter(result => result.isFailure())
+    if (errorResults.length > 0) {
+      console.log('End with failure')
+      return failure(new Error('Some runner throws error'))
+    }
+
+    return success()
   }
 }

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -26,14 +26,16 @@ export class CompositRunner implements Runner {
   }
 
   async run(): Promise<Result<void, Error>> {
-    const results = await Promise.all(
+    const results = await Promise.allSettled(
       this.runners.map((runner) => runner.run())
     )
 
-    const errorResults = results.filter(result => result.isFailure())
+    const errorResults = results.filter((result) => {
+      return result.status === 'rejected' ||
+        (result.status === 'fulfilled' && result.value.isFailure())
+    })
     if (errorResults.length > 0) {
-      console.log('End with failure')
-      return failure(new Error('Some runner throws error'))
+      return failure(new Error('Some runner throws error!!'))
     }
 
     return success()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "incremental": true,                   /* Enable incremental compilation */
     "target": "ES2019",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["es2020"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
## 1. Return error exit code when one of runner catch error
BREAKING CHANGE
Formerly, CIAnalyzer returns 0 despite of some runner throws error.
In this case, CIAnalyzer returns error code 1 now. 

## 2. Bugfix runner parallel execution aborted when some runner throws error
`Promise.all()` abort all parallel execution immediately when one of promise is rejected.
While `Promise.allSettled()` does not abort in this case, so it more suitable for parallel execution.