### PR TITLE
chore: Fix insecure interpolatoin code in sample Jenkinsfile

### DIFF
--- a/sample/cron.jenkinsfile
+++ b/sample/cron.jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
         CUSTOM_SCHEMA_DIR_PATH = credentials('ci_analyzer_custom_schema_dir') // secret text
       }
       steps {
-        sh """
+        sh '''
           docker pull kesin/ci_analyzer:latest
           docker run \
             --mount type=bind,src=${WORKSPACE},dst=/app/ \
@@ -25,7 +25,7 @@ pipeline {
             -e JENKINS_TOKEN=${JENKINS_PSW} \
             -e GOOGLE_APPLICATION_CREDENTIALS=/service_account.json \
             kesin/ci_analyzer:latest
-        """
+        '''
       }
       post {
         always {


### PR DESCRIPTION
The latest version of Jenkins alert me sample code of Jenkinsfile has insecure interpolation of sensitive variables.
https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#string-interpolation