### PR TITLE
feat: Export queuedDurationSec

### DIFF
--- a/bigquery_schema/workflow_report.json
+++ b/bigquery_schema/workflow_report.json
@@ -196,5 +196,10 @@
     "mode": "REPEATED", 
     "name": "parameters", 
     "type": "RECORD"
-  }
+  },
+  {
+    "mode": "NULLABLE", 
+    "name": "queuedDurationSec", 
+    "type": "FLOAT"
+  } 
 ]

--- a/src/analyzer/analyzer.ts
+++ b/src/analyzer/analyzer.ts
@@ -26,6 +26,7 @@ export type WorkflowReport = {
   sumJobsDurationSec: number
   successCount: 0 | 1 // = 'SUCCESS': 1, others: 0. For create average success rate in dashboard
   parameters: JobParameter[]
+  queuedDurationSec: number
 }
 
 export type JobReport = {

--- a/src/analyzer/circleci_analyzer.ts
+++ b/src/analyzer/circleci_analyzer.ts
@@ -25,7 +25,7 @@ type WorkflowReport = {
   sumJobsDurationSec: number // = sum(jobs sumStepsDurationSec)
   successCount: 0 | 1 // = 'SUCCESS': 1, others: 0
   parameters: [] // CircleciAnalyzer does not support output build parameters yet
-  queuedDurationSec: number // Not implemented yet
+  queuedDurationSec: number // createdAt - min(jobs start_time)
 }
 
 type JobReport = {
@@ -108,6 +108,7 @@ export class CircleciAnalyzer implements Analyzer {
     const startedAt = min(jobReports.map((job) => job.startedAt ))!
     const completedAt = max(jobReports.map((job) => job.completedAt ))!
     const status = this.normalizeStatus(lastJob.status)
+    const createdAt = min(jobs.map((job) => new Date(job.queued_at)))!
     // workflow
     return {
       service: 'circleci',
@@ -115,7 +116,7 @@ export class CircleciAnalyzer implements Analyzer {
       buildNumber,
       workflowRunId,
       workflowName,
-      createdAt: min(jobs.map((job) => new Date(job.queued_at)))!,
+      createdAt,
       trigger: firstJob.why,
       status,
       repository,
@@ -129,7 +130,7 @@ export class CircleciAnalyzer implements Analyzer {
       sumJobsDurationSec: secRound(sumBy(jobReports, 'sumStepsDurationSec')),
       successCount: (status === 'SUCCESS') ? 1 : 0,
       parameters: [],
-      queuedDurationSec: 0,
+      queuedDurationSec: diffSec(createdAt, min(jobs.map((job) => new Date(job.start_time)))!),
     }
   }
 

--- a/src/analyzer/circleci_analyzer.ts
+++ b/src/analyzer/circleci_analyzer.ts
@@ -25,6 +25,7 @@ type WorkflowReport = {
   sumJobsDurationSec: number // = sum(jobs sumStepsDurationSec)
   successCount: 0 | 1 // = 'SUCCESS': 1, others: 0
   parameters: [] // CircleciAnalyzer does not support output build parameters yet
+  queuedDurationSec: number // Not implemented yet
 }
 
 type JobReport = {
@@ -128,6 +129,7 @@ export class CircleciAnalyzer implements Analyzer {
       sumJobsDurationSec: secRound(sumBy(jobReports, 'sumStepsDurationSec')),
       successCount: (status === 'SUCCESS') ? 1 : 0,
       parameters: [],
+      queuedDurationSec: 0,
     }
   }
 

--- a/src/analyzer/github_analyzer.ts
+++ b/src/analyzer/github_analyzer.ts
@@ -28,6 +28,7 @@ type WorkflowReport = {
   sumJobsDurationSec: number // = sum(jobs sumStepsDurationSec)
   successCount: 0 | 1 // = 'SUCCESS': 1, others: 0
   parameters: [] // GithubAnalyzer does not support build parameters yet
+  queuedDurationSec: number // Not implemented yet
 }
 
 type JobReport = {
@@ -125,7 +126,8 @@ export class GithubAnalyzer implements Analyzer {
       workflowDurationSec: diffSec(startedAt, completedAt),
       sumJobsDurationSec: sumBy(jobReports, 'sumStepsDurationSec'),
       successCount: (status === 'SUCCESS') ? 1 : 0,
-      parameters: []
+      parameters: [],
+      queuedDurationSec: 0,
     }
   }
 

--- a/src/client/jenkins_client.ts
+++ b/src/client/jenkins_client.ts
@@ -81,7 +81,13 @@ export type BuildResponse = {
   number: number // 80
   fullDisplayName: string // "ci_analyzer #90",
   timestamp: number // 1605412528346 (milisec timestamp)
-  actions: (CauseAction | BuildData | GhprbParametersAction | ParametersAction)[]
+  actions: (
+    CauseAction |
+    BuildData |
+    GhprbParametersAction | // from GitHub Pull Request Builder plugin
+    ParametersAction |
+    TimeInQueueAction // from Metrics plugin
+  )[]
   artifacts: {
     displayPath: string // "junit.xml",
     fileName: string // "junit.xml",
@@ -146,6 +152,20 @@ export type ParametersAction = {
       name: string // "TIMEOUT",
       value?: string | number | boolean // "10"
     }[]
+}
+
+export type TimeInQueueAction = {
+  _class : "jenkins.metrics.impl.TimeInQueueAction",
+  blockedDurationMillis : number,
+  blockedTimeMillis : number,
+  buildableDurationMillis : number, // Freestyle job queued time
+  buildableTimeMillis : number, // Pipeline job queued time
+  buildingDurationMillis : number,
+  executingTimeMillis : number,
+  executorUtilization : number,
+  subTaskCount : number,
+  waitingDurationMillis : number,
+  waitingTimeMillis : number
 }
 
 export class JenkinsClient {

--- a/src/exporter/bigquery_exporter.ts
+++ b/src/exporter/bigquery_exporter.ts
@@ -85,6 +85,7 @@ export class BigqueryExporter implements Exporter {
         })
     } catch (error) {
       console.error(`(BigQuery) ERROR!! loading ${tmpJsonPath} to ${this.dataset}.${table}`)
+      console.error(error)
       throw error
     }
 


### PR DESCRIPTION
Correct queuedDurationSec that duration time in build queue and export it.

Jenkins needs to install [Metrics plugin](https://plugins.jenkins.io/metrics/) to correct queued time data.