### PR TITLE
fix(CircleCI): Ignore background step

### DIFF
--- a/src/client/circleci_client.ts
+++ b/src/client/circleci_client.ts
@@ -67,6 +67,7 @@ type Steps = {
     start_time: string,
     step: number,
     run_time_millis: number | null, // Sometimes step log will be broken and return null
+    background: boolean,
   }[]
 }
 export type SingleBuildResponse = RecentBuildResponse & {


### PR DESCRIPTION
Some CircleCI steps running background and these step times are almost the same as job duration.
e.g. https://circleci.com/docs/2.0/databases/

Background steps are not related to the critical path of workflow so it should be ignored.