### PR TITLE
fix: Skip fetch Jenkins job that has not any build

### DIFF
--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -35,6 +35,7 @@ export class CompositRunner implements Runner {
         (result.status === 'fulfilled' && result.value.isFailure())
     })
     if (errorResults.length > 0) {
+      errorResults.forEach((error) => console.error(error))
       return failure(new Error('Some runner throws error!!'))
     }
 


### PR DESCRIPTION
CIAnalyzer throws an error and stopping run when using `correctAllJobs` and your Jenkins has some jobs that has not any build histories.

`job/JOB_NAME/lastBuild/json` API returns 404 when the job has not any build histories.