### PR TITLE
ci: Enable to trigger push tag event for build Docker

### DIFF
--- a/.github/workflows/shipjs-trigger.yml
+++ b/.github/workflows/shipjs-trigger.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           fetch-depth: 0
           ref: master
+          # Workaround for trigger 'push tag' event for build Docker workflow
+          # see: https://github.community/t/action-does-not-trigger-another-on-push-tag-action/17148/4
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - uses: actions/setup-node@v1
         with:
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
This is a workaround for an issue that workflow can not trigger another one.

see:
https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
https://github.community/t/action-does-not-trigger-another-on-push-tag-action/17148/4