### PR TITLE
ci: Using GITHUB_TOKEN to push ghcr.io instead of PAT

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.ghcr_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v2


### PR DESCRIPTION
see: https://github.blog/changelog/2021-03-24-packages-container-registry-now-supports-github_token/