### PR TITLE
Fix Bitrise API max limit number

### DIFF
--- a/ci_analyzer.yaml
+++ b/ci_analyzer.yaml
@@ -74,7 +74,8 @@ jenkins:
 bitrise:
   baseUrl: https://api.bitrise.io/v0.1 # default
   apps:
-    # Bitrise {org_name}/{app_name}
+    # {repo_owner}/{title} from https://api.bitrise.io/v0.1/apps API response
+    # see: https://api-docs.bitrise.io/
     - name: Kesin11/FlutterGettingStarted
       tests:
         - "*_test_results.xml"

--- a/src/client/bitrise_client.ts
+++ b/src/client/bitrise_client.ts
@@ -6,6 +6,7 @@ import { CustomReportConfig } from '../config/config'
 
 const DEBUG_PER_PAGE = 10
 const NOT_FINISHED_STATUS = 0
+const MAX_LIMIT = 50
 
 // /apps/{app-slug}/builds
 // The status of the build: not finished (0), successful (1), failed (2), aborted with failure (3), aborted with success (4)
@@ -131,8 +132,7 @@ export class BitriseClient {
     const res = await this.axios.get( `apps/${appSlug}/builds`, {
       params: {
         sort_by: 'created_at',
-        // API default is 50 and max is unknown
-        limit: (process.env['CI_ANALYZER_DEBUG']) ? DEBUG_PER_PAGE : 100,
+        limit: (process.env['CI_ANALYZER_DEBUG']) ? DEBUG_PER_PAGE : MAX_LIMIT,
       }
     })
     let builds = res.data.data as BuildResponse[]
@@ -174,7 +174,7 @@ export class BitriseClient {
   async fetchArtifactsList(appSlug: string, buildSlug: string): Promise<ArtifactListResponse> {
     const res = await this.axios.get(
       `/apps/${appSlug}/builds/${buildSlug}/artifacts`,
-      { params: { limit: 50 }} // API allowed max 50
+      { params: { limit: MAX_LIMIT }}
     )
     return res.data.data as ArtifactListResponse
   }


### PR DESCRIPTION
ref: https://api-docs.bitrise.io/
/apps/{app-slug}/builds

> limit integer(query) | Max number of build artifacts per page is 50.

The document does not say max number of limit, but they return an error when request `limit: 100`.