### PR TITLE
Fix config key typo vsc -> vcs

### DIFF
--- a/__tests__/config/circleci_config.test.ts
+++ b/__tests__/config/circleci_config.test.ts
@@ -1,7 +1,7 @@
 import { parseConfig } from '../../src/config/circleci_config'
 
 describe('parseConfig', () => {
-  describe('vscType', () => {
+  describe('vcsType', () => {
     it('should github when value is repo string', () => {
       const config = {
         configDir: __dirname,
@@ -15,7 +15,7 @@ describe('parseConfig', () => {
         repos: [{
           owner: 'owner',
           repo: 'repo',
-          vscType: 'github',
+          vcsType: 'github',
           fullname: 'github/owner/repo',
           customReports: [],
         }]
@@ -26,7 +26,7 @@ describe('parseConfig', () => {
       const config = {
         configDir: __dirname,
         circleci: {
-          repos: [{ name: 'owner/repo', vsc_type: 'bitbucket' }]
+          repos: [{ name: 'owner/repo', vcs_type: 'bitbucket' }]
         }
       }
 
@@ -35,14 +35,14 @@ describe('parseConfig', () => {
         repos: [{
           owner: 'owner',
           repo: 'repo',
-          vscType: 'bitbucket',
+          vcsType: 'bitbucket',
           fullname: 'bitbucket/owner/repo',
           customReports: [],
         }]
       })
     })
 
-    it('should github when object vsc_type is null', () => {
+    it('should github when object vcs_type is null', () => {
       const config = {
         configDir: __dirname,
         circleci: {
@@ -55,7 +55,7 @@ describe('parseConfig', () => {
         repos: [{
           owner: 'owner',
           repo: 'repo',
-          vscType: 'github',
+          vcsType: 'github',
           fullname: 'github/owner/repo',
           customReports: [],
         }]
@@ -79,7 +79,7 @@ describe('parseConfig', () => {
       const actual = parseConfig(config)
       expect(actual).toEqual({
         repos: [{
-          owner: 'owner', repo: 'repo', vscType: 'github', fullname: 'github/owner/repo',
+          owner: 'owner', repo: 'repo', vcsType: 'github', fullname: 'github/owner/repo',
           customReports: [],
         }]
       })
@@ -99,7 +99,7 @@ describe('parseConfig', () => {
       const actual = parseConfig(config)
       expect(actual).toEqual({
         repos: [{
-          owner: 'owner', repo: 'repo', vscType: 'github', fullname: 'github/owner/repo',
+          owner: 'owner', repo: 'repo', vcsType: 'github', fullname: 'github/owner/repo',
           customReports: [ customReport ]
         }]
       })

--- a/ci_analyzer.yaml
+++ b/ci_analyzer.yaml
@@ -12,8 +12,6 @@ github:
           paths:
             - 'custom_report.json' # Path at inside of artifact.
     - Kesin11/Firestore-simple # Can use abbr format if don't collect test report
-  vcsBaseUrl: # It used for collect git tag data.
-    github: https://api.github.com # default
   exporter: &exporter # Can use yaml anchor
     local:
       outDir: ./output # default: output

--- a/ci_analyzer.yaml
+++ b/ci_analyzer.yaml
@@ -12,7 +12,7 @@ github:
           paths:
             - 'custom_report.json' # Path at inside of artifact.
     - Kesin11/Firestore-simple # Can use abbr format if don't collect test report
-  vscBaseUrl: # It used for collect git tag data.
+  vcsBaseUrl: # It used for collect git tag data.
     github: https://api.github.com # default
   exporter: &exporter # Can use yaml anchor
     local:
@@ -42,12 +42,12 @@ circleci:
   repos:
     - Kesin11/CIAnalyzer # Can use abbr format
     - name: Kesin11/CIAnalyzer
-      vsc_type: github # github or bitbucket. default: github
+      vcs_type: github # github or bitbucket. default: github
       customReports:
         - name: { CUSTOM_REPORT_NAME }
           paths:
             - 'custom_report.json'
-  vscBaseUrl:
+  vcsBaseUrl:
     # Using for collect git tag data. **Currently only support github**
     github: https://api.github.com # Change it if you using GitHub Enterprise Server
   exporter: *exporter # Can use yaml anchor

--- a/sample/ci_analyzer_circleci.yaml
+++ b/sample/ci_analyzer_circleci.yaml
@@ -3,7 +3,7 @@
 circleci:
   repos:
     - name: Kesin11/CIAnalyzer
-  vscBaseUrl:
+  vcsBaseUrl:
     github: https://api.github.com
   exporter:
     local:

--- a/src/config/circleci_config.ts
+++ b/src/config/circleci_config.ts
@@ -2,7 +2,7 @@ import { YamlConfig, CommonConfig, CustomReportConfig } from './config'
 
 export type CircleciConfig = CommonConfig & {
   repos: {
-    vscType: string
+    vcsType: string
     owner: string
     repo: string
     fullname: string
@@ -12,7 +12,7 @@ export type CircleciConfig = CommonConfig & {
 
 type RepoYaml = string | {
   name: string
-  vsc_type?: string
+  vcs_type?: string
   customReports?: CustomReportConfig[]
 }
 
@@ -26,18 +26,18 @@ export const parseConfig = (config: YamlConfig): CircleciConfig | undefined => {
     let owner, repo
     if (typeof repoYaml === 'string') {
       [owner, repo] = repoYaml.split('/')
-      const vscType = 'github'
-      const fullname = `${vscType}/${owner}/${repo}`
-      return { vscType, owner, repo, fullname, customReports: [] }
+      const vcsType = 'github'
+      const fullname = `${vcsType}/${owner}/${repo}`
+      return { vcsType, owner, repo, fullname, customReports: [] }
     }
 
     [owner, repo] = repoYaml.name.split('/')
-    const vscType = repoYaml.vsc_type ?? 'github'
+    const vcsType = repoYaml.vcs_type ?? 'github'
     return {
-      vscType,
+      vcsType,
       owner,
       repo,
-      fullname: `${vscType}/${owner}/${repo}`,
+      fullname: `${vcsType}/${owner}/${repo}`,
       customReports: repoYaml.customReports ?? [],
     }
   })

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -14,7 +14,7 @@ export type CommonConfig = {
   baseUrl?: string
   exporter?: ExporterConfig
   lastRunStore?: LastRunStoreConfig
-  vscBaseUrl?: {
+  vcsBaseUrl?: {
     github?: string
   }
 }

--- a/src/runner/circleci_runner.ts
+++ b/src/runner/circleci_runner.ts
@@ -27,7 +27,7 @@ export class CircleciRunner implements Runner {
     this.analyzer = new CircleciAnalyzer()
 
     const GITHUB_TOKEN = process.env['GITHUB_TOKEN'] || ''
-    this.githubClient = new GithubClient(GITHUB_TOKEN, this.config?.vscBaseUrl?.github)
+    this.githubClient = new GithubClient(GITHUB_TOKEN, this.config?.vcsBaseUrl?.github)
   }
 
   private setRepoLastRun(reponame: string, reports: WorkflowReport[]) {
@@ -52,7 +52,7 @@ export class CircleciRunner implements Runner {
 
       try {
         const lastRunId = this.store.getLastRun(repo.fullname)
-        const workflowRuns = await this.client.fetchWorkflowRuns(repo.owner, repo.repo, repo.vscType, lastRunId)
+        const workflowRuns = await this.client.fetchWorkflowRuns(repo.owner, repo.repo, repo.vcsType, lastRunId)
         const tagMap = await this.githubClient.fetchRepositoryTagMap(repo.owner, repo.repo)
 
         for (const workflowRun of workflowRuns) {

--- a/src/runner/github_runner.ts
+++ b/src/runner/github_runner.ts
@@ -23,7 +23,7 @@ export class GithubRunner implements Runner {
     const GITHUB_TOKEN = process.env['GITHUB_TOKEN'] || ''
     this.configDir = yamlConfig.configDir
     this.config = parseConfig(yamlConfig)
-    this.client = new GithubClient(GITHUB_TOKEN, this.config?.vscBaseUrl?.github)
+    this.client = new GithubClient(GITHUB_TOKEN, this.config?.baseUrl)
     this.analyzer = new GithubAnalyzer()
   }
 


### PR DESCRIPTION
BREAKING CHANGES

Fix typo key in CIAnalyzer config yaml.

- `vsc_type` -> `vcs_type`
- `vscBaseUrl` -> `vcsBaseUrl`

So please fix key name in config yaml if you use these keys.