### PR TITLE
Support using CircleCI API v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ See sample [cron.jenkinsfile](./sample/cron.jenkinsfile).
 - [x] Collect test data
 - [x] Collect any of JSON format from build artifacts
 - [x] Support Bitrise
-- [ ] Support CircleCI API v2
+- [x] Support CircleCI API v2
 - [x] Implement better logger
 - [ ] Support to fetch past build result
 

--- a/__tests__/client/circleci_client.test.ts
+++ b/__tests__/client/circleci_client.test.ts
@@ -3,6 +3,9 @@ import { ArgumentOptions } from '../../src/arg_options'
 import { CircleciClient } from '../../src/client/circleci_client'
 
 const logger = new Logger({ minLevel: 'warn' })
+const options = new ArgumentOptions({
+  "c": "./dummy.yaml"
+})
 
 const allCompletedRuns = [
   { build_nums: [2,3], last_build_num: 3, lifecycles: ['finished','finished'] },
@@ -31,6 +34,42 @@ const hasNotRunAndInprogressRuns = [
 ] as any
 
 describe('CircleciClient', () => {
+  describe('new() with baseUrl', () => {
+    it('should OK when undefined', async () => {
+      expect(() => {
+        new CircleciClient('DUMMY_TOKEN', logger, options)
+      }).toBeTruthy()
+    })
+
+    it('should OK when /api/v1.1', async () => {
+      const baseUrl = 'https://circleci.com/api/v1.1'
+      expect(() => {
+        new CircleciClient('DUMMY_TOKEN', logger, options, baseUrl)
+      }).toBeTruthy()
+    })
+
+    it('should OK when /api/v1.1/', async () => {
+      const baseUrl = 'https://circleci.com/api/v1.1/'
+      expect(() => {
+        new CircleciClient('DUMMY_TOKEN', logger, options, baseUrl)
+      }).toBeTruthy()
+    })
+
+    it('should throw when /api', async () => {
+      const baseUrl = 'https://circleci.com/api'
+      expect(() => {
+        new CircleciClient('DUMMY_TOKEN', logger, options, baseUrl)
+      }).toThrow()
+    })
+
+    it('should throw when /api/v2', async () => {
+      const baseUrl = 'https://circleci.com/api/v2'
+      expect(() => {
+        new CircleciClient('DUMMY_TOKEN', logger, options, baseUrl)
+      }).toThrow()
+    })
+  })
+
   describe('filterWorkflowRuns', () => {
     let client: CircleciClient
     const options = new ArgumentOptions({

--- a/__tests__/client/circleci_client_v2.test.ts
+++ b/__tests__/client/circleci_client_v2.test.ts
@@ -1,0 +1,46 @@
+import { Logger } from 'tslog'
+import { ArgumentOptions } from '../../src/arg_options'
+import { CircleciClientV2 } from '../../src/client/circleci_client_v2'
+
+const logger = new Logger({ minLevel: 'warn' })
+const options = new ArgumentOptions({
+  "c": "./dummy.yaml"
+})
+
+describe('CircleciClient', () => {
+  describe('new() with baseUrl', () => {
+    it('should OK when undefined', async () => {
+      expect(() => {
+        new CircleciClientV2('DUMMY_TOKEN', logger, options)
+      }).toBeTruthy()
+    })
+
+    it('should OK when /api', async () => {
+      const baseUrl = 'https://circleci.com/api'
+      expect(() => {
+        new CircleciClientV2('DUMMY_TOKEN', logger, options, baseUrl)
+      }).toBeTruthy()
+    })
+
+    it('should OK when /api/', async () => {
+      const baseUrl = 'https://circleci.com/api/'
+      expect(() => {
+        new CircleciClientV2('DUMMY_TOKEN', logger, options, baseUrl)
+      }).toBeTruthy()
+    })
+
+    it('should throw when /api/v1.1', async () => {
+      const baseUrl = 'https://circleci.com/api/v1.1'
+      expect(() => {
+        new CircleciClientV2('DUMMY_TOKEN', logger, options, baseUrl)
+      }).toThrow()
+    })
+
+    it('should throw when /api/v2', async () => {
+      const baseUrl = 'https://circleci.com/api/v2'
+      expect(() => {
+        new CircleciClientV2('DUMMY_TOKEN', logger, options, baseUrl)
+      }).toThrow()
+    })
+  })
+})

--- a/__tests__/config/circleci_config.test.ts
+++ b/__tests__/config/circleci_config.test.ts
@@ -17,7 +17,8 @@ describe('parseConfig', () => {
           vcsType: 'github',
           fullname: 'github/owner/repo',
           customReports: [],
-        }]
+        }],
+        version: "1_1"
       })
     })
 
@@ -36,7 +37,8 @@ describe('parseConfig', () => {
           vcsType: 'bitbucket',
           fullname: 'bitbucket/owner/repo',
           customReports: [],
-        }]
+        }],
+        version: "1_1"
       })
     })
 
@@ -55,7 +57,8 @@ describe('parseConfig', () => {
           vcsType: 'github',
           fullname: 'github/owner/repo',
           customReports: [],
-        }]
+        }],
+        version: "1_1"
       })
     })
   })
@@ -77,7 +80,8 @@ describe('parseConfig', () => {
         repos: [{
           owner: 'owner', repo: 'repo', vcsType: 'github', fullname: 'github/owner/repo',
           customReports: [],
-        }]
+        }],
+        version: "1_1"
       })
     })
 
@@ -96,8 +100,58 @@ describe('parseConfig', () => {
         repos: [{
           owner: 'owner', repo: 'repo', vcsType: 'github', fullname: 'github/owner/repo',
           customReports: [ customReport ]
-        }]
+        }],
+        version: "1_1"
       })
+    })
+  })
+
+  describe('version', () => {
+    it("should '1_1' when empty", () => {
+      const config = {
+        circleci: {
+          repos: [ 'owner/repo' ]
+        }
+      }
+
+      const actual = parseConfig(config)
+      expect(actual!.version).toEqual("1_1")
+    })
+
+    it("should '2' when version: 2(Number)", () => {
+      const config = {
+        circleci: {
+          repos: [ 'owner/repo' ],
+          version: 2,
+        }
+      }
+
+      const actual = parseConfig(config)
+      expect(actual!.version).toEqual("2")
+    })
+
+    it("should '2' when version: 2(String)", () => {
+      const config = {
+        circleci: {
+          repos: [ 'owner/repo' ],
+          version: "2",
+        }
+      }
+
+      const actual = parseConfig(config)
+      expect(actual!.version).toEqual("2")
+    })
+
+    it("should '1_1' when unknown value", () => {
+      const config = {
+        circleci: {
+          repos: [ 'owner/repo' ]
+        },
+        version: "1000"
+      }
+
+      const actual = parseConfig(config)
+      expect(actual!.version).toEqual("1_1")
     })
   })
 })

--- a/__tests__/config/circleci_config.test.ts
+++ b/__tests__/config/circleci_config.test.ts
@@ -18,7 +18,7 @@ describe('parseConfig', () => {
           fullname: 'github/owner/repo',
           customReports: [],
         }],
-        version: "1_1"
+        version: 1
       })
     })
 
@@ -38,7 +38,7 @@ describe('parseConfig', () => {
           fullname: 'bitbucket/owner/repo',
           customReports: [],
         }],
-        version: "1_1"
+        version: 1
       })
     })
 
@@ -58,7 +58,7 @@ describe('parseConfig', () => {
           fullname: 'github/owner/repo',
           customReports: [],
         }],
-        version: "1_1"
+        version: 1
       })
     })
   })
@@ -81,7 +81,7 @@ describe('parseConfig', () => {
           owner: 'owner', repo: 'repo', vcsType: 'github', fullname: 'github/owner/repo',
           customReports: [],
         }],
-        version: "1_1"
+        version: 1
       })
     })
 
@@ -101,13 +101,13 @@ describe('parseConfig', () => {
           owner: 'owner', repo: 'repo', vcsType: 'github', fullname: 'github/owner/repo',
           customReports: [ customReport ]
         }],
-        version: "1_1"
+        version: 1
       })
     })
   })
 
   describe('version', () => {
-    it("should '1_1' when empty", () => {
+    it("should 1 when empty", () => {
       const config = {
         circleci: {
           repos: [ 'owner/repo' ]
@@ -115,10 +115,34 @@ describe('parseConfig', () => {
       }
 
       const actual = parseConfig(config)
-      expect(actual!.version).toEqual("1_1")
+      expect(actual!.version).toEqual(1)
     })
 
-    it("should '2' when version: 2(Number)", () => {
+    it("should 1 when version: 1(Number)", () => {
+      const config = {
+        circleci: {
+          repos: [ 'owner/repo' ],
+          version: 1,
+        },
+      }
+
+      const actual = parseConfig(config)
+      expect(actual!.version).toEqual(1)
+    })
+
+    it("should 1 when version: 1(Number)", () => {
+      const config = {
+        circleci: {
+          repos: [ 'owner/repo' ],
+          version: '1',
+        },
+      }
+
+      const actual = parseConfig(config)
+      expect(actual!.version).toEqual(1)
+    })
+
+    it("should 2 when version: 2(Number)", () => {
       const config = {
         circleci: {
           repos: [ 'owner/repo' ],
@@ -127,31 +151,31 @@ describe('parseConfig', () => {
       }
 
       const actual = parseConfig(config)
-      expect(actual!.version).toEqual("2")
+      expect(actual!.version).toEqual(2)
     })
 
-    it("should '2' when version: 2(String)", () => {
+    it("should 2 when version: 2(String)", () => {
       const config = {
         circleci: {
           repos: [ 'owner/repo' ],
-          version: "2",
+          version: '2',
         }
       }
 
       const actual = parseConfig(config)
-      expect(actual!.version).toEqual("2")
+      expect(actual!.version).toEqual(2)
     })
 
-    it("should '1_1' when unknown value", () => {
+    it("should 1 when unknown value", () => {
       const config = {
         circleci: {
-          repos: [ 'owner/repo' ]
+          repos: [ 'owner/repo' ],
+          version: "1000"
         },
-        version: "1000"
       }
 
       const actual = parseConfig(config)
-      expect(actual!.version).toEqual("1_1")
+      expect(actual!.version).toEqual(1)
     })
   })
 })

--- a/__tests__/config/jenkins_config.test.ts
+++ b/__tests__/config/jenkins_config.test.ts
@@ -10,7 +10,14 @@ describe('parseConfig', () => {
     }
 
     const actual = parseConfig(config)
-    expect(actual).toEqual(config.jenkins)
+    expect(actual).toEqual({
+      baseUrl: 'http://localhost:8080',
+      jobs: [{
+        name: 'sample-job',
+        testGlob: [],
+        customReports: []
+      }]
+    })
   })
 
   describe('when repos are object', () => {

--- a/__tests__/last_run_store.test.ts
+++ b/__tests__/last_run_store.test.ts
@@ -52,6 +52,73 @@ describe('LastRunStore', () => {
 
       expect(lastRunStore.lastRun[repo].lastRun).toEqual(101)
     })
+
+    it('update lastRun only', async () => {
+      lastRunStore.lastRun[repo] = {
+        lastRun: 0,
+        updatedAt: new Date(),
+        meta: { version: 2 }
+      }
+      lastRunStore.setLastRun(repo, 100)
+
+      expect(lastRunStore.lastRun[repo]).toEqual({
+        lastRun: 100,
+        updatedAt: expect.anything(),
+        meta: { version: 2 }
+      })
+    })
+  })
+
+  describe('resetLastRun', () => {
+    it('should accept when current lastRun is undefined', async () => {
+      lastRunStore.resetLastRun(repo)
+
+      expect(lastRunStore.lastRun[repo].lastRun).toEqual(0)
+    })
+
+    it('should accept when current lastRun is defined', async () => {
+      lastRunStore.lastRun[repo] = {
+        lastRun: 100,
+        updatedAt: new Date()
+      }
+      lastRunStore.resetLastRun(repo)
+
+      expect(lastRunStore.lastRun[repo].lastRun).toEqual(0)
+    })
+
+    it('reset lastRun only', async () => {
+      lastRunStore.lastRun[repo] = {
+        lastRun: 100,
+        updatedAt: new Date(),
+        meta: { version: 2 }
+      }
+      lastRunStore.resetLastRun(repo)
+
+      expect(lastRunStore.lastRun[repo]).toEqual({
+        lastRun: 0,
+        updatedAt: expect.anything(),
+        meta: { version: 2 }
+      })
+    })
+  })
+
+  it('getMeta', async () => {
+    lastRunStore.lastRun[repo] = {
+      lastRun: 100,
+      updatedAt: new Date(),
+      meta: {
+        version: 2,
+      }
+    }
+
+    expect(lastRunStore.getMeta(repo)).toEqual({ version: 2 })
+  })
+
+  it('setMeta', async () => {
+    lastRunStore.setLastRun(repo, 100)
+    lastRunStore.setMeta(repo, { version: 2 })
+
+    expect(lastRunStore.lastRun[repo].meta).toEqual({ version: 2 })
   })
 
   it('save', async () => {

--- a/__tests__/runner/circleci_runner_v1.test.ts
+++ b/__tests__/runner/circleci_runner_v1.test.ts
@@ -1,0 +1,95 @@
+import { CircleciRunnerV1, CircleciV1LastRunMetadata } from '../../src/runner/circleci_runner_v1'
+import { Logger } from 'tslog'
+import { ArgumentOptions } from '../../src/arg_options'
+import { LastRunStore } from '../../src/last_run_store'
+import { NullStore } from '../../src/store/null_store'
+
+const logger = new Logger({ minLevel: 'warn' })
+const argOptions = new ArgumentOptions({
+  c: 'cianalyzer.yml',
+  v: 0,
+  debug: true,
+})
+const repo = 'owner/repo'
+const config = {
+  circleci: {
+    repos: [ repo ],
+    version: 1
+  },
+}
+
+describe('migrateLastRun', () => {
+  let runner: CircleciRunnerV1
+  beforeEach(async () => {
+    runner = new CircleciRunnerV1(logger, config, argOptions)
+    const nullStore = new NullStore(logger)
+    runner.store = new LastRunStore<CircleciV1LastRunMetadata>(nullStore)
+  })
+
+  it('new repo', async () => {
+    runner.migrateLastRun(repo)
+
+    expect(runner.store!.lastRun[repo]).toEqual({
+      updatedAt: expect.anything(),
+      meta: {
+        version: 1
+      }
+    })
+  })
+
+  it('undefined metadata to version:1', async () => {
+    runner.store!.lastRun[repo] = {
+      lastRun: 1,
+      updatedAt: new Date(),
+      meta: undefined,
+    }
+    runner.migrateLastRun(repo)
+
+    expect(runner.store!.lastRun[repo]).toEqual({
+      lastRun: 1,
+      updatedAt: expect.anything(),
+      meta: {
+        version: 1
+      }
+    })
+  })
+
+  it('version:1 to version:1', async () => {
+    runner.store!.lastRun[repo] = {
+      lastRun: 1,
+      updatedAt: new Date(),
+      meta: {
+        version: 1
+      }
+    }
+    runner.migrateLastRun(repo)
+
+    expect(runner.store!.getMeta(repo)).toEqual({ version: 1 })
+  })
+
+  it('version:2 to version:1', async () => {
+    runner.store!.lastRun[repo] = {
+      lastRun: 1,
+      updatedAt: new Date(),
+      meta: {
+        version: 2
+      }
+    }
+    expect(()=> {
+      runner.migrateLastRun(repo)
+    }).toThrow()
+  })
+
+  it('version:>2 to version:1', async () => {
+    runner.store!.lastRun[repo] = {
+      lastRun: 1,
+      updatedAt: new Date(),
+      meta: {
+        version: 3
+      }
+    }
+    expect(()=> {
+      runner.migrateLastRun(repo)
+    }).toThrow()
+  })
+})

--- a/__tests__/runner/circleci_runner_v2.test.ts
+++ b/__tests__/runner/circleci_runner_v2.test.ts
@@ -1,0 +1,103 @@
+import { CircleciRunnerV2, CircleciV2LastRunMetadata } from '../../src/runner/circleci_runner_v2'
+import { Logger } from 'tslog'
+import { ArgumentOptions } from '../../src/arg_options'
+import { LastRunStore } from '../../src/last_run_store'
+import { NullStore } from '../../src/store/null_store'
+
+const logger = new Logger({ minLevel: 'warn' })
+const argOptions = new ArgumentOptions({
+  c: 'cianalyzer.yml',
+  v: 0,
+  debug: true,
+})
+const repo = 'owner/repo'
+const config = {
+  circleci: {
+    repos: [ repo ],
+    version: 2
+  },
+}
+
+describe('migrateLastRun', () => {
+  let runner: CircleciRunnerV2
+  beforeEach(async () => {
+    runner = new CircleciRunnerV2(logger, config, argOptions)
+    const nullStore = new NullStore(logger)
+    runner.store = new LastRunStore<CircleciV2LastRunMetadata>(nullStore)
+  })
+
+  it('new repo', async () => {
+    runner.migrateLastRun(repo)
+
+    expect(runner.store!.lastRun[repo]).toEqual({
+      lastRun: 0,
+      updatedAt: expect.anything(),
+      meta: {
+        version: 2
+      }
+    })
+  })
+
+  it('undefined metadata to version:2', async () => {
+    runner.store!.lastRun[repo] = {
+      lastRun: 1,
+      updatedAt: new Date(),
+      meta: undefined,
+    }
+    runner.migrateLastRun(repo)
+
+    expect(runner.store!.lastRun[repo]).toEqual({
+      lastRun: 0,
+      updatedAt: expect.anything(),
+      meta: {
+        version: 2
+      }
+    })
+  })
+
+  it('version:1 to version:2', async () => {
+    runner.store!.lastRun[repo] = {
+      lastRun: 1,
+      updatedAt: new Date(),
+      meta: {
+        version: 1
+      }
+    }
+    runner.migrateLastRun(repo)
+
+    expect(runner.store!.getMeta(repo)).toEqual({ version: 2 })
+  })
+
+  it('version:2 to version:2', async () => {
+    const lastRun = 1
+    runner.store!.lastRun[repo] = {
+      lastRun,
+      updatedAt: new Date(),
+      meta: {
+        version: 2
+      }
+    }
+    runner.migrateLastRun(repo)
+
+    expect(runner.store!.lastRun[repo]).toEqual({
+      lastRun,
+      updatedAt: expect.anything(),
+      meta: {
+        version: 2
+      }
+    })
+  })
+
+  it('version:>2 to version:2', async () => {
+    runner.store!.lastRun[repo] = {
+      lastRun: 1,
+      updatedAt: new Date(),
+      meta: {
+        version: 3
+      }
+    }
+    expect(()=> {
+      runner.migrateLastRun(repo)
+    }).toThrow()
+  })
+})

--- a/ci_analyzer.yaml
+++ b/ci_analyzer.yaml
@@ -37,6 +37,7 @@ github:
 
 circleci:
   # baseUrl: https://circleci.com/api/v1.1 # Change it if you using CircleCI Enterprise
+  version: 2
   repos:
     - Kesin11/CIAnalyzer # Can use abbr format
     - name: Kesin11/CIAnalyzer

--- a/ci_analyzer.yaml
+++ b/ci_analyzer.yaml
@@ -36,7 +36,7 @@ github:
     path: ci_analyzer/last_run/github.json # (Optional) default: ci_analyzer/last_run/${service}.json
 
 circleci:
-  # baseUrl: https://circleci.com/api/v1.1 # Change it if you using CircleCI Enterprise
+  # baseUrl: https://circleci.com/api/ # Change it if you using CircleCI Enterprise
   version: 2
   repos:
     - Kesin11/CIAnalyzer # Can use abbr format

--- a/sample/ci_analyzer_circleci.yaml
+++ b/sample/ci_analyzer_circleci.yaml
@@ -1,6 +1,7 @@
 # Export to BigQuery and Local
 # Save LastRun to Local file and cache with CircleCI cache
 circleci:
+  version: 2
   repos:
     - name: Kesin11/CIAnalyzer
   vcsBaseUrl:

--- a/src/analyzer/circleci_analyzer_v2.ts
+++ b/src/analyzer/circleci_analyzer_v2.ts
@@ -111,9 +111,9 @@ export class CircleciAnalyzerV2 implements Analyzer {
     const sortedJobs = sortBy(workflow.jobs, 'job_number')
     const firstJob = first(sortedJobs)
     const createdAt = new Date(workflow.created_at) 
-    // Sometimes worklfow has not valid jobs. ex: Pipeline status is "Build error"
+    // Sometimes worklfow has invalid timestamps, so remediate it.
     const startedAt = new Date(firstJob?.started_at ?? workflow.created_at)
-    const completedAt = new Date(workflow.stopped_at)
+    const completedAt = new Date(workflow.stopped_at ?? startedAt)
     const status = this.normalizeWorkflowStatus(workflow.status)
     // workflow
     return {

--- a/src/analyzer/circleci_analyzer_v2.ts
+++ b/src/analyzer/circleci_analyzer_v2.ts
@@ -1,0 +1,237 @@
+import { sumBy, sortBy, first } from "lodash"
+import { Status, diffSec, Analyzer, secRound, TestReport, WorkflowParams, convertToReportTestSuites } from "./analyzer"
+import { JobTest } from "../client/circleci_client_v2"
+import { TestSuite, TestCase } from "junit2json"
+import { Pipeline, Workflow } from "../client/circleci_client_v2"
+import { CircleciStatus } from "../client/circleci_client"
+
+type WorkflowReport = {
+  service: 'circleci',
+  workflowId: string, // = ${repository}-${workflowName}
+  workflowRunId: string, // = ${repository}-${workflowName}-${buildNumber}
+  buildNumber: number, // pipeline.number
+  workflowName: string,
+  createdAt: Date, // = workflow.created_at
+  trigger: string // = pipeline.trigger.type
+  status: Status,
+  repository: string,
+  headSha: string, // = pipeline.vcs.revision
+  branch: string,
+  tag: string, // = pipeline.trigger.type
+  jobs: JobReport[],
+  startedAt: Date, // = min(jobs start_time)
+  completedAt: Date // = workflow.stopped_at
+  workflowDurationSec: number // = completedAt - startedAt
+  sumJobsDurationSec: number // = sum(jobs sumStepsDurationSec)
+  successCount: 0 | 1 // = 'SUCCESS': 1, others: 0
+  parameters: [] // CircleciAnalyzerV2 does not support output build parameters yet
+  queuedDurationSec: number // createdAt - startedAt
+}
+
+type JobReport = {
+  workflowRunId: string, // = workflowRunId
+  buildNumber: number, // = job.job_number
+  jobId: string, // = job.id
+  jobName: string, // = job.name
+  status: Status,
+  startedAt: Date, // job.started_at
+  completedAt: Date, // job.stopped_at
+  jobDurationSec: number, // = completedAt - startedAt
+  sumStepsDurationSec: number // = sum(steps duration)
+  steps: StepReport[],
+}
+
+type StepReport = {
+  name: string,
+  status: Status,
+  number: number,
+  startedAt: Date,
+  completedAt: Date,
+  stepDurationSec: number // run_time_millis
+}
+
+export class CircleciAnalyzerV2 implements Analyzer {
+  constructor() { }
+
+  createWorkflowParams(workflowName: string, repository: string, buildNumber: number): WorkflowParams {
+    return {
+      workflowName,
+      buildNumber,
+      workflowId: `${repository}-${workflowName}`,
+      workflowRunId: `${repository}-${workflowName}-${buildNumber}`
+    }
+  }
+
+  createWorkflowReport( pipeline: Pipeline, workflow: Workflow): WorkflowReport {
+    const repository = workflow.project_slug.split('/').slice(1).join('/')
+    const { workflowName, workflowId, buildNumber, workflowRunId }
+      = this.createWorkflowParams(workflow.name, repository, pipeline.number)
+
+    const jobReports: JobReport[] = workflow.jobs.map((job) => {
+      const stepReports: StepReport[] = job.steps
+        .filter((step) => {
+          const action = first(step.actions)!
+          // NOTE: Ignore background step (ex. Setup service container image step)
+          return action.background === false
+        })
+        .map((step) => {
+          const action = first(step.actions)!
+          const startedAt = new Date(action.start_time)
+          // NOTE: Sometimes action.end_time will be broken, so it should be replaced when it's value is invalid.
+          const validatedEndTime = action.end_time ?? action.start_time
+          const completedAt = new Date(validatedEndTime)
+          // step
+          return {
+            name: action.name,
+            status: this.normalizeStatus(action.status),
+            number: action.step,
+            startedAt,
+            completedAt,
+            stepDurationSec: diffSec(startedAt, completedAt)
+          }
+        })
+
+      const startedAt = new Date(job.started_at)
+      const completedAt = new Date(job.stopped_at ?? job.started_at)
+      // job
+      return {
+        workflowRunId,
+        buildNumber: job.job_number,
+        jobId: job.id,
+        jobName: job.name,
+        status: this.normalizeStatus(job.status as CircleciStatus),
+        startedAt,
+        completedAt,
+        jobDurationSec: diffSec(startedAt, completedAt),
+        sumStepsDurationSec: secRound(sumBy(stepReports, 'stepDurationSec')),
+        steps: stepReports,
+      }
+    })
+
+    const sortedJobs = sortBy(workflow.jobs, 'job_number')
+    const firstJob = first(sortedJobs)
+    const createdAt = new Date(workflow.created_at) 
+    // Sometimes worklfow has not valid jobs. ex: Pipeline status is "Build error"
+    const startedAt = new Date(firstJob?.started_at ?? workflow.created_at)
+    const completedAt = new Date(workflow.stopped_at)
+    const status = this.normalizeWorkflowStatus(workflow.status)
+    // workflow
+    return {
+      service: 'circleci',
+      workflowId,
+      buildNumber,
+      workflowRunId,
+      workflowName,
+      createdAt,
+      trigger: pipeline.trigger.type,
+      status,
+      repository,
+      headSha: pipeline.vcs.revision,
+      branch: pipeline.vcs.branch ?? '',
+      tag: pipeline.vcs.tag ?? '',
+      jobs: jobReports,
+      startedAt,
+      completedAt,
+      workflowDurationSec: diffSec(startedAt, completedAt),
+      sumJobsDurationSec: secRound(sumBy(jobReports, 'sumStepsDurationSec')),
+      successCount: (status === 'SUCCESS') ? 1 : 0,
+      parameters: [],
+      queuedDurationSec: diffSec(createdAt, startedAt), // firstJob.started_at - workflow.created_at
+    }
+  }
+
+  private normalizeStatus(status: CircleciStatus): Status {
+    switch (status) {
+      case 'success':
+        return 'SUCCESS'
+      case 'fixed':
+        return 'SUCCESS'
+      case 'failed':
+        return 'FAILURE'
+      case 'canceled':
+        return 'ABORTED'
+      case 'timedout':
+        return 'ABORTED'
+      default:
+        return 'OTHER';
+    }
+  }
+
+  private normalizeWorkflowStatus(status: Workflow['status']): Status {
+    switch (status) {
+      case 'success':
+        return 'SUCCESS'
+      case 'failed':
+        return 'FAILURE'
+      case 'failing':
+        return 'FAILURE'
+      case 'error':
+        return 'FAILURE'
+      case 'canceled':
+        return 'ABORTED'
+      default:
+        return 'OTHER';
+    }
+  }
+
+  async createTestReports( workflowReports: WorkflowReport[], tests: JobTest[]): Promise<TestReport[]> {
+    const testReports: TestReport[] = []
+    for (const workflowReport of workflowReports) {
+      // Filter tests that related to workflow jobs
+      const jobAndJobTests = workflowReport.jobs.map((job) => {
+        return {
+          job,
+          jobTest: tests.find((test) => test.jobNumber === job.buildNumber)
+        }
+      })
+      const testSuiteList: TestSuite[] = jobAndJobTests
+        .filter(({ jobTest }) => jobTest && jobTest.tests.length > 0 )
+        .map(({ job, jobTest }) => {
+          // TestCases = CircleCI tests
+          const testCases: TestCase[] = jobTest!.tests.map((test) => {
+            return {
+              classname: test.classname,
+              name: test.name,
+              time: test.run_time,
+              failure: (test.result === 'failure') ? [{ inner: test.message ?? '' }] : undefined,
+              skipped: (test.result === 'skipped') ? [{ message: test.message ?? '' }] : undefined,
+            }
+          })
+          // TestSuite = CircleCI Job
+          return {
+            name: job.jobName,
+            time: secRound(sumBy(testCases, 'time')),
+            tests: testCases.length,
+            failures: testCases.filter((testcase) => testcase.failure !== undefined).length,
+            skipped: testCases.filter((testcase) => testcase.skipped !== undefined).length,
+            timestamp: job.startedAt.toISOString(),
+            testcase: testCases,
+          }
+        })
+
+      if (testSuiteList.length === 0 ) continue
+
+      // TestSuiets = CircleCI Workflow
+      const testSuites = {
+        name: workflowReport.workflowName,
+        time: secRound(sumBy(testSuiteList, 'time')),
+        tests: sumBy(testSuiteList, 'tests'),
+        failures: sumBy(testSuiteList, 'failures'),
+        testsuite: testSuiteList,
+      }
+      testReports.push({
+        workflowId: workflowReport.workflowId,
+        workflowRunId: workflowReport.workflowRunId,
+        buildNumber: workflowReport.buildNumber,
+        workflowName: workflowReport.workflowName,
+        createdAt: workflowReport.createdAt,
+        branch: workflowReport.branch,
+        service: workflowReport.service,
+        testSuites: convertToReportTestSuites(testSuites),
+        status: (testSuites.failures > 0) ? 'FAILURE' : 'SUCCESS',
+        successCount: (testSuites.failures > 0) ? 0 : 1,
+      })
+    }
+    return testReports
+  }
+}

--- a/src/client/circleci_client.ts
+++ b/src/client/circleci_client.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import minimatch from 'minimatch'
 import { AxiosInstance } from 'axios'
 import { groupBy, max, minBy } from 'lodash'
@@ -113,6 +114,9 @@ type ArtifactsResponse = {
 export class CircleciClient {
   private axios: AxiosInstance
   constructor(token: string, logger: Logger, private options: ArgumentOptions, baseUrl?: string) {
+    if (baseUrl && path.basename(baseUrl) !== 'v1.1') {
+      throw `${CircleciClient.name} accepts only "/api/v1.1/" But your baseUrl is ${baseUrl}`
+    }
     const axiosLogger = logger.getChildLogger({ name: CircleciClient.name })
     this.axios = createAxios(axiosLogger, {
       baseURL: baseUrl ?? 'https://circleci.com/api/v1.1',

--- a/src/client/circleci_client.ts
+++ b/src/client/circleci_client.ts
@@ -110,7 +110,6 @@ type ArtifactsResponse = {
   url: string,
 }[]
 
-
 export class CircleciClient {
   private axios: AxiosInstance
   constructor(token: string, logger: Logger, private options: ArgumentOptions, baseUrl?: string) {
@@ -200,6 +199,17 @@ export class CircleciClient {
     return runs
   }
 
+  async fetchWorkflowJobs(workflowRun: WorkflowRun) {
+    return await Promise.all(workflowRun.build_nums.map((buildNum) => {
+      return this.fetchJobs(
+        workflowRun.username,
+        workflowRun.reponame,
+        workflowRun.vcs_type,
+        buildNum
+        )
+    }))
+  }
+
   // ex: https://circleci.com/api/v1.1/project/github/Kesin11/CIAnalyzer/1021
   async fetchJobs(owner: string, repo: string, vcsType: string, runId: number) {
     const res = await this.axios.get( `project/${vcsType}/${owner}/${repo}/${runId}`, {})
@@ -221,6 +231,17 @@ export class CircleciClient {
       workflow_id: `${repo}-workflow-${startTime.getTime()}`,
       workflow_name: 'workflow'
     }
+  }
+
+  async fetchWorkflowTests(workflowRun: WorkflowRun) {
+    return await Promise.all(workflowRun.build_nums.map((buildNum) => {
+      return this.fetchTests(
+        workflowRun.username,
+        workflowRun.reponame,
+        workflowRun.vcs_type,
+        buildNum
+      )
+    }))
   }
 
   // ex: https://circleci.com/api/v1.1/project/github/Kesin11/CIAnalyzer/1021/tests
@@ -257,6 +278,18 @@ export class CircleciClient {
       })
     }
     return artifacts
+  }
+
+  async fetchWorkflowCustomReports(workflowRun: WorkflowRun, customReportConfigs: CustomReportConfig[]) {
+    return await Promise.all(workflowRun.build_nums.map((buildNum) => {
+      return this.fetchCustomReports(
+        workflowRun.username,
+        workflowRun.reponame,
+        workflowRun.vcs_type,
+        buildNum,
+        customReportConfigs,
+      )
+    }))
   }
 
   async fetchCustomReports(owner: string, repo: string, vcsType: string, runId: number, customReportsConfigs: CustomReportConfig[]): Promise<CustomReportArtifact> {

--- a/src/client/circleci_client_v2.ts
+++ b/src/client/circleci_client_v2.ts
@@ -1,0 +1,405 @@
+import minimatch from 'minimatch'
+import { AxiosInstance } from 'axios'
+import { minBy } from 'lodash'
+import { Artifact, CustomReportArtifact, createAxios } from './client'
+import { CustomReportConfig } from '../config/config'
+import { ArgumentOptions } from '../arg_options'
+import { Logger } from 'tslog'
+import { failure, Result, success } from '../result'
+import { CircleciStatus } from './circleci_client'
+import { Overwrite } from 'utility-types'
+
+const DEBUG_PER_PAGE = 5
+
+type V2ApiResponse = {
+  items: unknown[],
+  next_page_token: string | null
+}
+
+type ListPipelinesForProjectResponse = {
+  items: {
+    id: string, // "f9bc9389-26a6-411f-9ad4-abda516625f3",
+    errors: {
+      type: "config" | "plan",
+      message: string
+    }[],
+    project_slug: string, // "gh/Kesin11/CIAnalyzer",
+    updated_at?: string, // "2021-08-29T17:27:13.320Z",
+    number: number, // 1133,
+    state: "created" | "errored" | "setup-pending" | "setup" | "pending",
+    created_at: string, // "2021-08-29T17:27:13.320Z",
+    trigger: {
+      received_at: string, // "2021-08-29T17:27:13.120Z",
+      type: "explicit" | "api" | "webhook",
+      actor: {
+        login: string, // "renovate[bot]",
+        avatar_url: string | null, // null
+      }
+    },
+    vcs: {
+      origin_repository_url: string, // "https://github.com/Kesin11/CIAnalyzer",
+      target_repository_url: string, // "https://github.com/Kesin11/CIAnalyzer",
+      revision: string, // "c069387dac988ac5f778c9f189c5aaa46d2809f8",
+      provider_name: string, // "GitHub",
+      commit: {
+        body: string, // "",
+        subject: string, //"chore(deps): update dependency jest to v27.1.0"
+      } | undefined,
+      branch?: string, // "renovate/jest-packages"
+      tag?: string
+      review_id?: string,
+      review_url?: string,
+    }
+  }[],
+  next_page_token: string | null
+}
+
+type ListWorkflowsByPipelineIdResponse = {
+  items: {
+    pipeline_id : string, // "5a99319f-67b2-4273-8ff3-4f04af90552b",
+    canceled_by?: string,
+    id : string, // "a8b7b739-bfb8-4bfc-aa29-cab8b2b07b9f",
+    name : string, // "docker",
+    project_slug : string, // "gh/Kesin11/CIAnalyzer",
+    status : "success" | "running" | "not_run" | "failed" | "error" | "failing" | "on_hold" | "canceled" | "unauthorized",
+    started_by : string, // "0989fcb2-c8d2-43ed-bfdd-3ff63487e121",
+    pipeline_number : number, // 1152,
+    created_at : string, // "2021-09-04T19:59:05Z",
+    stopped_at : string, // "2021-09-04T19:59:57Z"
+  }[],
+  next_page_token: string | null
+}
+
+export type Pipeline = ListPipelinesForProjectResponse["items"][0]
+  & { workflows: ListWorkflowsByPipelineIdResponse["items"] }
+
+type ListWorkflowJobsResponse = {
+  items : {
+    canceled_by? : string,
+    dependencies : string[], // [],
+    job_number? : number, // 3405,
+    id : string, // "d70a655a-57d7-4a7f-b177-34332f4c7355",
+    started_at? : string | null, // "2021-09-04T19:59:11Z",
+    name : string, //"lint",
+    approved_by?: string,
+    project_slug : string,// "gh/Kesin11/CIAnalyzer",
+    status : "success" | "failed" | "blocked" // NOTE: API document says 'any' type but I found enum.
+    type : "build" | "approval",
+    stopped_at? : string, // "2021-09-04T19:59:30Z"
+    approval_request_id?: string,
+  }[],
+  next_page_token: string | null,
+}
+
+type FilteredWorkflowJob = Overwrite<
+  ListWorkflowJobsResponse["items"][0],
+  { job_number: number, started_at: string}
+>
+
+type GetJobDetailsResponse = {
+  web_url : string, // "https://circleci.com/gh/Kesin11/CIAnalyzer/3405",
+  project : {
+    external_url : string, // "https://github.com/Kesin11/CIAnalyzer",
+    slug : string, // "gh/Kesin11/CIAnalyzer",
+    name : string, // "CIAnalyzer"
+  },
+  parallel_runs : {
+    index : number, // 0,
+    status : string, // "success"
+  }[],
+  started_at : string, // "2021-09-04T19:59:11.975Z",
+  latest_workflow : {
+    name : string, // "ci",
+    id : string, // "0a7edade-5785-406a-9c31-3fce94cddad4"
+  },
+  name : string, // "lint",
+  executor : {
+    resource_class : string, // "medium",
+    type : string, // "docker"
+  },
+  parallelism : number, // 1,
+  status : string, // "success",
+  number : number, // 3405,
+  pipeline : {
+    id : string, // "5a99319f-67b2-4273-8ff3-4f04af90552b"
+  },
+  duration : number, // 18371,
+  created_at : string, // "2021-09-04T19:59:06.288Z",
+  messages : { // []
+    type: string,
+    message: string,
+    reason?: string,
+  }[],
+  contexts : { // []
+    name: string,
+  }[],
+  organization : {
+    name : string, // "Kesin11"
+  },
+  queued_at : string, // "2021-09-04T19:59:06.400Z",
+  stopped_at? : string, // "2021-09-04T19:59:30.346Z"
+}
+
+export type Workflow = ListWorkflowsByPipelineIdResponse["items"][0]
+  & { jobs: Job[] }
+
+type Job = FilteredWorkflowJob
+    & { detail: GetJobDetailsResponse, steps: Step[] }
+
+type Step = {
+  name: string
+  actions: {
+    name: string
+    status: CircleciStatus
+    end_time: string | null, // Sometimes step log will be broken and return null
+    start_time: string,
+    step: number,
+    run_time_millis: number | null, // Sometimes step log will be broken and return null
+    background: boolean,
+  }[]
+}
+
+type v1_1SingleJobResponse = {
+  build_num: number,
+  steps: Step[]
+}
+
+type TestResponse = {
+  items: {
+    name : string, // "successCount = 1 when testcase is success",
+    file : string | null, // null
+    classname : string, // "Analyzer convertToReportTestSuites Add testcase.successCount",
+    result : string, // "success",
+    run_time : number, // 0.0,
+    message : string | null, // null,
+    source : string, // "unknown"
+  }[]
+  next_page_token: string | null,
+}
+
+export type JobTest = {
+  tests: TestResponse["items"]
+  jobNumber: number
+}
+
+type ArtifactsResponse = {
+  items: {
+    path : string, // "custom_report.json",
+    node_index : number, // 0,
+    url : string, // "https://3587-259687475-gh.circle-artifacts.com/0/custom_report.json"
+  }[]
+  next_page_token: string | null,
+}
+
+type ArtifactItem = ArtifactsResponse["items"][0]
+
+export class CircleciClientV2 {
+  private axios: AxiosInstance
+  private baseUrl: string
+  constructor(token: string, logger: Logger, private options: ArgumentOptions, baseUrl?: string) {
+    const axiosLogger = logger.getChildLogger({ name: CircleciClientV2.name })
+    this.baseUrl = baseUrl ?? 'https://circleci.com/api',
+    this.axios = createAxios(axiosLogger, {
+      baseURL: this.baseUrl,
+      auth: {
+        username: token,
+        password: '',
+      },
+    })
+  }
+
+  async isHostAvailableVersion(): Promise<Result<unknown, Error>> {
+    try {
+      await this.axios.get( `v2/me`, {} )
+    } catch (error) {
+      return failure(new Error(`${this.baseUrl} unavailable API v2`))
+    }
+
+    return success(`${this.baseUrl} available API v2`)
+  }
+
+  private async fetchV2Api<T extends V2ApiResponse>(url: string, requestParams?: {[key: string]: unknown}): Promise<T["items"]> {
+      const items: T["items"] = []
+      for (let pageToken = undefined; pageToken !== null;) {
+        const res = await this.axios.get(url, {
+          params: {
+            ...requestParams,
+            "page-token": pageToken,
+          }
+        })
+        const data = res.data as T
+        items.push(...data.items)
+        pageToken = data.next_page_token
+      }
+      return items
+  }
+
+  // https://circleci.com/docs/api/v2/#operation/listPipelines
+  // https://circleci.com/docs/api/v2/#operation/listWorkflowsByPipelineId
+  async fetchWorkflowRuns(owner: string, repo: string, vcsType: string, lastRunId?: number): Promise<Pipeline[]> {
+    const limit = (this.options.debug) ? DEBUG_PER_PAGE : 100
+    let recentPipelines = [] as ListPipelinesForProjectResponse["items"]
+    for (let length = 0, pageToken = undefined; length < limit;) {
+      const res = await this.axios.get( `v2/project/${vcsType}/${owner}/${repo}/pipeline`, {
+        params: {
+          "page-token": pageToken,
+        }
+      })
+      const data = res.data as ListPipelinesForProjectResponse
+      recentPipelines.push(...data.items)
+      length = recentPipelines.length
+      pageToken = data.next_page_token
+    }
+    if (this.options.debug) recentPipelines = recentPipelines.slice(0, DEBUG_PER_PAGE)
+
+    // TODO: v1からv2へのマイグレーション時の考慮が必要
+    recentPipelines = (lastRunId)
+      ? recentPipelines.filter((pipeline) => pipeline.number > lastRunId)
+      : recentPipelines
+    
+    const pipelines = [] as Pipeline[]
+    for (const recentPipeline of recentPipelines) {
+      const workflows = await this.fetchV2Api<ListWorkflowsByPipelineIdResponse>(`v2/pipeline/${recentPipeline.id}/workflow`)
+      pipelines.push({ ...recentPipeline, workflows: workflows })
+    }
+
+    return this.filterPipelines(pipelines)
+  }
+
+  // Filter pipelines with last build number < first running build number
+  // And also ignore still running pipelines.
+  private filterPipelines (pipelines: Pipeline[]): Pipeline[] {
+    // Ignore not_run workflows that are [ci-skip] commit OR skipped redundant build
+    pipelines = pipelines.filter((pipeline) => { return !pipeline.workflows.some((workflow) => workflow.status === 'not_run') })
+
+    const inprogressPipeline = pipelines.filter((pipeline) => {
+      return pipeline.workflows.every((workflow) => workflow.status === 'running' || workflow.status === 'on_hold')
+    })
+    const firstInprogress = minBy(
+      inprogressPipeline,
+      (pipeline) => pipeline.number,
+    )
+    pipelines = (firstInprogress)
+      ? pipelines.filter((pipeline) => pipeline.number < firstInprogress.number)
+      : pipelines
+    return pipelines
+  }
+
+  async fetchPipelineWorkflows(pipeline: Pipeline): Promise<Workflow[]> {
+    const workflows: Workflow[] = []
+    for (const workflow of pipeline.workflows) {
+      const jobResponses = await this.fetchWorkflowJobs(workflow.id)
+      // Filter jobs that has not job_number
+      const filterdWorkflowJobs = jobResponses.filter((jobResponse) => {
+        return jobResponse.status !== "blocked"
+          && jobResponse.job_number !== undefined
+      }) as FilteredWorkflowJob[]
+
+      // Fetch jobDetail and steps in parallel and then Combine to job
+      const jobDetails = await Promise.all(filterdWorkflowJobs.map((workflowJob) => {
+        return this.fetchJob(workflowJob.job_number, workflowJob.project_slug)
+      }))
+      const jobSteps = await Promise.all(filterdWorkflowJobs.map((workflowJob) => {
+        return this.fetchJobSteps(workflowJob.job_number, workflowJob.project_slug)
+      }))
+      const jobs: Job[] = filterdWorkflowJobs.map((workflowJobs) => {
+        return {
+          ...workflowJobs,
+          detail: jobDetails.find((detail) => detail.number === workflowJobs.job_number)!,
+          steps: jobSteps.find((step) => step.build_num === workflowJobs.job_number)?.steps ?? [],
+        }
+      })
+
+      workflows.push({ ...workflow, jobs })
+    }
+
+    return workflows
+  }
+
+  // https://circleci.com/docs/api/v2/#operation/listWorkflowJobs
+  private async fetchWorkflowJobs(workflowId: string) {
+    const jobs = await this.fetchV2Api<ListWorkflowJobsResponse>(`v2/workflow/${workflowId}/job`)
+    return jobs
+  }
+
+  // https://circleci.com/docs/api/v2/#operation/getJobDetails
+  private async fetchJob(jobNumber: number, projectSlug: string) {
+    const res = await this.axios.get( `v2/project/${projectSlug}/job/${jobNumber}`, {})
+    return res.data as GetJobDetailsResponse
+  }
+
+
+  // https://circleci.com/docs/api/v1/#single-job
+  private async fetchJobSteps(jobNumber: number, projectSlug: string) {
+    const res = await this.axios.get( `v1.1/project/${projectSlug}/${jobNumber}`, {})
+    return res.data as v1_1SingleJobResponse
+  }
+
+  async fetchWorkflowsTests(workflows: Workflow[]): Promise<JobTest[]> {
+    const jobs = workflows.flatMap((workflow) => workflow.jobs)
+    return Promise.all(jobs.map((job) => {
+      return this.fetchTests(job.job_number, job.project_slug)
+    }))
+  }
+
+  // https://circleci.com/docs/api/v2/#operation/getTests
+  async fetchTests(jobNumber: number, projectSlug: string): Promise<JobTest> {
+    const tests = await this.fetchV2Api<TestResponse>(`v2/project/${projectSlug}/${jobNumber}/tests`)
+    return { tests, jobNumber }
+  }
+
+  async fetchWorkflowCustomReports(workflow: Workflow, customReportConfigs: CustomReportConfig[]) {
+    return await Promise.all(workflow.jobs.map((job) => {
+      return this.fetchCustomReports(job.job_number, job.project_slug, customReportConfigs)
+    }))
+  }
+
+  private async fetchCustomReports(jobNumber: number, projectSlug: string, customReportsConfigs: CustomReportConfig[]): Promise<CustomReportArtifact> {
+    // Skip if custom report config are not provided
+    if (customReportsConfigs?.length < 1) return new Map()
+
+    const artifacts = await this.fetchArtifactsList(jobNumber, projectSlug)
+
+    // Fetch artifacts in parallel
+    const customReports: CustomReportArtifact = new Map<string, Artifact[]>()
+    const nameArtifacts = customReportsConfigs.map((customReportConfig) => {
+      const reportArtifacts = artifacts.filter((artifact) => {
+        return customReportConfig.paths.some((glob) => minimatch(artifact.path, glob))
+      })
+      return {
+        name: customReportConfig.name,
+        artifacts: this.fetchArtifacts(reportArtifacts)
+      }
+    })
+    for (const { name, artifacts } of nameArtifacts) {
+      customReports.set(name, await artifacts)
+    }
+
+    return customReports
+  }
+
+  // https://circleci.com/docs/api/v2/#operation/getJobArtifacts
+  private async fetchArtifactsList(jobNumber: number, projectSlug: string): Promise<ArtifactItem[]> {
+    const artifacts = await this.fetchV2Api<ArtifactsResponse>(`v2/project/${projectSlug}/${jobNumber}/artifacts`)
+    return artifacts
+  }
+
+  private async fetchArtifacts(artifactItems: ArtifactItem[]): Promise<Artifact[]> {
+    const pathResponses = artifactItems.map((artifactItem) => {
+      const response = this.axios.get(
+        artifactItem.url,
+        { responseType: 'arraybuffer'}
+      )
+      return { path: artifactItem.path, response }
+    })
+
+    const artifacts = []
+    for (const { path, response } of pathResponses) {
+      artifacts.push({
+        path,
+        data: (await response).data as ArrayBuffer
+      })
+    }
+    return artifacts
+  }
+}

--- a/src/client/circleci_client_v2.ts
+++ b/src/client/circleci_client_v2.ts
@@ -11,7 +11,7 @@ import { CircleciStatus } from './circleci_client'
 import { Overwrite } from 'utility-types'
 
 const DEBUG_FETCH_LIMIT = 5
-const FETCH_LIMIT = 30
+const FETCH_LIMIT = 100
 
 type V2ApiResponse = {
   items: unknown[],

--- a/src/client/circleci_client_v2.ts
+++ b/src/client/circleci_client_v2.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import minimatch from 'minimatch'
 import { AxiosInstance } from 'axios'
 import { minBy } from 'lodash'
@@ -198,6 +199,9 @@ export class CircleciClientV2 {
   private axios: AxiosInstance
   private baseUrl: string
   constructor(token: string, logger: Logger, private options: ArgumentOptions, baseUrl?: string) {
+    if (baseUrl && path.basename(baseUrl) !== 'api') {
+      throw `${CircleciClientV2.name} accepts only "/api/" But your baseUrl is ${baseUrl}`
+    }
     const axiosLogger = logger.getChildLogger({ name: CircleciClientV2.name })
     this.baseUrl = baseUrl ?? 'https://circleci.com/api',
     this.axios = createAxios(axiosLogger, {

--- a/src/client/circleci_client_v2.ts
+++ b/src/client/circleci_client_v2.ts
@@ -275,11 +275,15 @@ export class CircleciClientV2 {
   // Filter pipelines with last build number < first running build number
   // And also ignore still running pipelines.
   private filterPipelines (pipelines: Pipeline[]): Pipeline[] {
-    // Ignore not_run workflows that are [ci-skip] commit OR skipped redundant build
-    pipelines = pipelines.filter((pipeline) => { return !pipeline.workflows.some((workflow) => workflow.status === 'not_run') })
+    // Ignore pipeline that has not any workflows.
+    // Ignore pipeline that has 'not_run' status workflows that are [ci-skip] commit OR skipped redundant build.
+    pipelines = pipelines.filter((pipeline) => {
+      return pipeline.workflows.length > 0
+        && !pipeline.workflows.some((workflow) => workflow.status === 'not_run')
+    })
 
     const inprogressPipeline = pipelines.filter((pipeline) => {
-      return pipeline.workflows.every((workflow) => workflow.status === 'running' || workflow.status === 'on_hold')
+      return pipeline.workflows.every((workflow) => workflow.status === 'running')
     })
     const firstInprogress = minBy(
       inprogressPipeline,

--- a/src/config/bitrise_config.ts
+++ b/src/config/bitrise_config.ts
@@ -19,7 +19,7 @@ type AppYaml = string | {
 export const parseConfig = (config: YamlConfig): BitriseConfig | undefined => {
   if (!config.bitrise) return
 
-  const bitriseConfig = config.bitrise
+  const bitriseConfig = { ...config.bitrise }
 
   // overwrite repos
   bitriseConfig.apps = (bitriseConfig.apps as AppYaml[]).map((appYaml): BitriseConfig['apps'][0] => {

--- a/src/config/circleci_config.ts
+++ b/src/config/circleci_config.ts
@@ -22,7 +22,7 @@ type RepoYaml = string | {
 export const parseConfig = (config: YamlConfig): CircleciConfig | undefined => {
   if (!config.circleci) return
 
-  const circleciConfig = config.circleci
+  const circleciConfig = { ...config.circleci }
 
   // overwrite repos
   circleciConfig.repos = (circleciConfig.repos as RepoYaml[]).map((repoYaml): CircleciConfig['repos'][0] => {

--- a/src/config/circleci_config.ts
+++ b/src/config/circleci_config.ts
@@ -11,6 +11,7 @@ export type CircleciConfig = CommonConfig & {
   vcsBaseUrl?: {
     github?: string
   }
+  version: "1_1" | "2"
 }
 
 type RepoYaml = string | {
@@ -23,6 +24,8 @@ export const parseConfig = (config: YamlConfig): CircleciConfig | undefined => {
   if (!config.circleci) return
 
   const circleciConfig = { ...config.circleci }
+
+  circleciConfig.version = (String(circleciConfig.version) === "2") ? "2" : "1_1"
 
   // overwrite repos
   circleciConfig.repos = (circleciConfig.repos as RepoYaml[]).map((repoYaml): CircleciConfig['repos'][0] => {

--- a/src/config/circleci_config.ts
+++ b/src/config/circleci_config.ts
@@ -11,7 +11,7 @@ export type CircleciConfig = CommonConfig & {
   vcsBaseUrl?: {
     github?: string
   }
-  version: "1_1" | "2"
+  version: 1 | 2
 }
 
 type RepoYaml = string | {
@@ -25,7 +25,7 @@ export const parseConfig = (config: YamlConfig): CircleciConfig | undefined => {
 
   const circleciConfig = { ...config.circleci }
 
-  circleciConfig.version = (String(circleciConfig.version) === "2") ? "2" : "1_1"
+  circleciConfig.version = (String(circleciConfig.version) === "2") ? 2 : 1
 
   // overwrite repos
   circleciConfig.repos = (circleciConfig.repos as RepoYaml[]).map((repoYaml): CircleciConfig['repos'][0] => {

--- a/src/config/github_config.ts
+++ b/src/config/github_config.ts
@@ -19,7 +19,7 @@ type RepoYaml = string | {
 export const parseConfig = (config: YamlConfig): GithubConfig | undefined => {
   if (!config.github) return
 
-  const githubConfig = config.github
+  const githubConfig = { ...config.github }
   // overwrite repos
   githubConfig.repos = (githubConfig.repos as RepoYaml[]).map((repoYaml): GithubConfig['repos'][0] => {
     let owner, repo

--- a/src/config/jenkins_config.ts
+++ b/src/config/jenkins_config.ts
@@ -23,7 +23,7 @@ type JobYaml = string | {
 export const parseConfig = (config: YamlConfig): JenkinsConfig | undefined => {
   if (!config.jenkins) return
 
-  const jenkinsConfig = config.jenkins
+  const jenkinsConfig = { ...config.jenkins }
   // overwrite jobs
   jenkinsConfig.jobs = (jenkinsConfig.jobs as JobYaml[]).map((jobYaml): JenkinsConfig['jobs'][0] => {
     if (typeof jobYaml === 'string') {

--- a/src/runner/circleci_runner.ts
+++ b/src/runner/circleci_runner.ts
@@ -1,125 +1,37 @@
-import { maxBy } from "lodash"
 import { Runner } from "./runner"
 import { YamlConfig } from "../config/config"
-import { CircleciClient } from "../client/circleci_client"
-import { CircleciAnalyzer } from "../analyzer/circleci_analyzer"
-import { CircleciConfig, parseConfig } from "../config/circleci_config"
-import { WorkflowReport, TestReport } from "../analyzer/analyzer"
-import { CompositExporter } from "../exporter/exporter"
-import { LastRunStore } from "../last_run_store"
-import { GithubClient } from "../client/github_client"
-import { CustomReportCollection, createCustomReportCollection, aggregateCustomReportArtifacts } from "../custom_report_collection"
-import { failure, Result, success } from "../result"
 import { ArgumentOptions } from "../arg_options"
 import { Logger } from "tslog"
+import { CircleciRunnerV1 } from "./circleci_runner_v1"
+import { CircleciRunnerV2 } from "./circleci_runner_v2"
+import { parseConfig } from "../config/circleci_config"
+import { Result } from "../result"
 
 export class CircleciRunner implements Runner {
-  service: string = 'circleci'
-  client: CircleciClient
-  analyzer: CircleciAnalyzer 
-  config: CircleciConfig | undefined
-  store?: LastRunStore
-  githubClient: GithubClient
+  config: YamlConfig
   logger: Logger
-
-  constructor(logger: Logger, public yamlConfig: YamlConfig, public options: ArgumentOptions) {
-    const CIRCLECI_TOKEN = process.env['CIRCLECI_TOKEN'] || ''
-    this.config = parseConfig(yamlConfig)
-    this.logger = logger.getChildLogger({ name: CircleciRunner.name, instanceName: this.service })
-    this.client = new CircleciClient(CIRCLECI_TOKEN, this.logger, options, this.config?.baseUrl)
-    this.analyzer = new CircleciAnalyzer()
-
-    const GITHUB_TOKEN = process.env['GITHUB_TOKEN'] || ''
-    this.githubClient = new GithubClient(GITHUB_TOKEN, options, this.config?.vcsBaseUrl?.github)
-  }
-
-  private setRepoLastRun(reponame: string, reports: WorkflowReport[]) {
-    const lastRunReport = maxBy(reports, 'buildNumber')
-    if (lastRunReport) {
-      this.store?.setLastRun(reponame, lastRunReport.buildNumber)
-    }
+  options: ArgumentOptions
+  constructor(logger: Logger, yamlConfig: YamlConfig, options: ArgumentOptions) {
+    this.logger = logger
+    this.config = yamlConfig
+    this.options = options
   }
 
   async run (): Promise<Result<unknown, Error>> {
-    let result: Result<unknown, Error> = success(this.service)
-    if (!this.config) return failure(new Error('this.config must not be undefined'))
-    this.store = await LastRunStore.init(this.logger, this.options, this.service, this.config.lastRunStore)
-
-    let workflowReports: WorkflowReport[] = []
-    let testReports: TestReport[] = []
-    const customReportCollection = new CustomReportCollection()
-    for (const repo of this.config.repos) {
-      this.logger.info(`Fetching ${this.service} - ${repo.fullname} ...`)
-      const repoWorkflowReports: WorkflowReport[] = []
-      let repoTestReports: TestReport[] = []
-
-      try {
-        const lastRunId = this.store.getLastRun(repo.fullname)
-        const workflowRuns = await this.client.fetchWorkflowRuns(repo.owner, repo.repo, repo.vcsType, lastRunId)
-        const tagMap = await this.githubClient.fetchRepositoryTagMap(repo.owner, repo.repo)
-
-        for (const workflowRun of workflowRuns) {
-          // Fetch data
-          const jobs = await Promise.all(workflowRun.build_nums.map((buildNum) => {
-            return this.client.fetchJobs(
-              workflowRun.username,
-              workflowRun.reponame,
-              workflowRun.vcs_type,
-              buildNum
-              )
-          }))
-          const tests = await Promise.all(workflowRun.build_nums.map((buildNum) => {
-            return this.client.fetchTests(
-              workflowRun.username,
-              workflowRun.reponame,
-              workflowRun.vcs_type,
-              buildNum
-            )
-          }))
-          const customReportArtifactsList = await Promise.all(workflowRun.build_nums.map((buildNum) => {
-            return this.client.fetchCustomReports(
-              workflowRun.username,
-              workflowRun.reponame,
-              workflowRun.vcs_type,
-              buildNum,
-              repo.customReports,
-            )
-          }))
-          const customReportArtifacts = aggregateCustomReportArtifacts(customReportArtifactsList)
-
-          // Create report
-          const workflowReport = this.analyzer.createWorkflowReport(workflowRun, jobs, tagMap)
-          const testReports = await this.analyzer.createTestReports(workflowReport, jobs, tests)
-          const runCustomReportCollection = await createCustomReportCollection(workflowReport, customReportArtifacts)
-
-          // Aggregate
-          repoWorkflowReports.push(workflowReport)
-          repoTestReports = repoTestReports.concat(testReports)
-          customReportCollection.aggregate(runCustomReportCollection)
-        }
-
-        this.setRepoLastRun(repo.fullname, repoWorkflowReports)
-        workflowReports = workflowReports.concat(repoWorkflowReports)
-        testReports = testReports.concat(repoTestReports)
-      }
-      catch (error) {
-        const errorMessage = `Some error raised in '${repo.fullname}', so it skipped.`
-        this.logger.error(errorMessage)
-        this.logger.error(error)
-        result = failure(new Error(errorMessage))
-        continue
-      }
+    let runner: CircleciRunnerV1 | CircleciRunnerV2
+    const config = parseConfig(this.config)
+    switch (config?.version) {
+      case "2":
+        runner = new CircleciRunnerV2(this.logger, this.config, this.options)
+        break;
+      default:
+        runner = new CircleciRunnerV1(this.logger, this.config, this.options)
+        break;
     }
 
-    this.logger.info(`Exporting ${this.service} workflow reports ...`)
-    const exporter = new CompositExporter(this.logger, this.options, this.service, this.config.exporter)
-    await exporter.exportWorkflowReports(workflowReports)
-    await exporter.exportTestReports(testReports)
-    await exporter.exportCustomReports(customReportCollection)
+    const hostAvailableResult = await runner.isHostAvailableVersion()
+    if (hostAvailableResult.isFailure()) return hostAvailableResult
 
-    this.store.save()
-    this.logger.info(`Done execute '${this.service}'. status: ${result.type}`)
-
-    return result
+    return await runner.run()
   }
 }

--- a/src/runner/circleci_runner.ts
+++ b/src/runner/circleci_runner.ts
@@ -21,7 +21,7 @@ export class CircleciRunner implements Runner {
     let runner: CircleciRunnerV1 | CircleciRunnerV2
     const config = parseConfig(this.config)
     switch (config?.version) {
-      case "2":
+      case 2:
         runner = new CircleciRunnerV2(this.logger, this.config, this.options)
         break;
       default:

--- a/src/runner/circleci_runner_v1.ts
+++ b/src/runner/circleci_runner_v1.ts
@@ -1,0 +1,129 @@
+import { maxBy } from "lodash"
+import { Runner } from "./runner"
+import { YamlConfig } from "../config/config"
+import { CircleciClient } from "../client/circleci_client"
+import { CircleciAnalyzer } from "../analyzer/circleci_analyzer"
+import { CircleciConfig, parseConfig } from "../config/circleci_config"
+import { WorkflowReport, TestReport } from "../analyzer/analyzer"
+import { CompositExporter } from "../exporter/exporter"
+import { LastRunStore } from "../last_run_store"
+import { GithubClient } from "../client/github_client"
+import { CustomReportCollection, createCustomReportCollection, aggregateCustomReportArtifacts } from "../custom_report_collection"
+import { failure, Result, success } from "../result"
+import { ArgumentOptions } from "../arg_options"
+import { Logger } from "tslog"
+
+export class CircleciRunnerV1 implements Runner {
+  service: string = 'circleci'
+  client: CircleciClient
+  analyzer: CircleciAnalyzer 
+  config: CircleciConfig | undefined
+  store?: LastRunStore
+  githubClient: GithubClient
+  logger: Logger
+
+  constructor(logger: Logger, public yamlConfig: YamlConfig, public options: ArgumentOptions) {
+    const CIRCLECI_TOKEN = process.env['CIRCLECI_TOKEN'] || ''
+    this.config = parseConfig(yamlConfig)
+    this.logger = logger.getChildLogger({ name: CircleciRunnerV1.name, instanceName: this.service })
+    this.client = new CircleciClient(CIRCLECI_TOKEN, this.logger, options, this.config?.baseUrl)
+    this.analyzer = new CircleciAnalyzer()
+
+    const GITHUB_TOKEN = process.env['GITHUB_TOKEN'] || ''
+    this.githubClient = new GithubClient(GITHUB_TOKEN, options, this.config?.vcsBaseUrl?.github)
+  }
+
+  async isHostAvailableVersion(): Promise<Result<unknown, Error>> {
+    return success(`${this.config?.baseUrl} available API v1.1`)
+  }
+
+  private setRepoLastRun(reponame: string, reports: WorkflowReport[]) {
+    const lastRunReport = maxBy(reports, 'buildNumber')
+    if (lastRunReport) {
+      this.store?.setLastRun(reponame, lastRunReport.buildNumber)
+    }
+  }
+
+  async run (): Promise<Result<unknown, Error>> {
+    let result: Result<unknown, Error> = success(this.service)
+    if (!this.config) return failure(new Error('this.config must not be undefined'))
+    this.store = await LastRunStore.init(this.logger, this.options, this.service, this.config.lastRunStore)
+
+    let workflowReports: WorkflowReport[] = []
+    let testReports: TestReport[] = []
+    const customReportCollection = new CustomReportCollection()
+    for (const repo of this.config.repos) {
+      this.logger.info(`Fetching ${this.service} - ${repo.fullname} ...`)
+      const repoWorkflowReports: WorkflowReport[] = []
+      let repoTestReports: TestReport[] = []
+
+      try {
+        const lastRunId = this.store.getLastRun(repo.fullname)
+        const workflowRuns = await this.client.fetchWorkflowRuns(repo.owner, repo.repo, repo.vcsType, lastRunId)
+        const tagMap = await this.githubClient.fetchRepositoryTagMap(repo.owner, repo.repo)
+
+        for (const workflowRun of workflowRuns) {
+          // Fetch data
+          const jobs = await Promise.all(workflowRun.build_nums.map((buildNum) => {
+            return this.client.fetchJobs(
+              workflowRun.username,
+              workflowRun.reponame,
+              workflowRun.vcs_type,
+              buildNum
+              )
+          }))
+          const tests = await Promise.all(workflowRun.build_nums.map((buildNum) => {
+            return this.client.fetchTests(
+              workflowRun.username,
+              workflowRun.reponame,
+              workflowRun.vcs_type,
+              buildNum
+            )
+          }))
+          const customReportArtifactsList = await Promise.all(workflowRun.build_nums.map((buildNum) => {
+            return this.client.fetchCustomReports(
+              workflowRun.username,
+              workflowRun.reponame,
+              workflowRun.vcs_type,
+              buildNum,
+              repo.customReports,
+            )
+          }))
+          const customReportArtifacts = aggregateCustomReportArtifacts(customReportArtifactsList)
+
+          // Create report
+          const workflowReport = this.analyzer.createWorkflowReport(workflowRun, jobs, tagMap)
+          const testReports = await this.analyzer.createTestReports(workflowReport, jobs, tests)
+          const runCustomReportCollection = await createCustomReportCollection(workflowReport, customReportArtifacts)
+
+          // Aggregate
+          repoWorkflowReports.push(workflowReport)
+          repoTestReports = repoTestReports.concat(testReports)
+          customReportCollection.aggregate(runCustomReportCollection)
+        }
+
+        this.setRepoLastRun(repo.fullname, repoWorkflowReports)
+        workflowReports = workflowReports.concat(repoWorkflowReports)
+        testReports = testReports.concat(repoTestReports)
+      }
+      catch (error) {
+        const errorMessage = `Some error raised in '${repo.fullname}', so it skipped.`
+        this.logger.error(errorMessage)
+        this.logger.error(error)
+        result = failure(new Error(errorMessage))
+        continue
+      }
+    }
+
+    this.logger.info(`Exporting ${this.service} workflow reports ...`)
+    const exporter = new CompositExporter(this.logger, this.options, this.service, this.config.exporter)
+    await exporter.exportWorkflowReports(workflowReports)
+    await exporter.exportTestReports(testReports)
+    await exporter.exportCustomReports(customReportCollection)
+
+    this.store.save()
+    this.logger.info(`Done execute '${this.service}'. status: ${result.type}`)
+
+    return result
+  }
+}

--- a/src/runner/circleci_runner_v2.ts
+++ b/src/runner/circleci_runner_v2.ts
@@ -1,0 +1,108 @@
+import { max } from "lodash"
+import { Runner } from "./runner"
+import { YamlConfig } from "../config/config"
+import { CircleciConfig, parseConfig } from "../config/circleci_config"
+import { WorkflowReport, TestReport } from "../analyzer/analyzer"
+import { CompositExporter } from "../exporter/exporter"
+import { LastRunStore } from "../last_run_store"
+import { GithubClient } from "../client/github_client"
+import { CustomReportCollection, createCustomReportCollection, aggregateCustomReportArtifacts } from "../custom_report_collection"
+import { failure, Result, success } from "../result"
+import { ArgumentOptions } from "../arg_options"
+import { Logger } from "tslog"
+import { CircleciClientV2, Pipeline } from "../client/circleci_client_v2"
+import { CircleciAnalyzerV2 } from "../analyzer/circleci_analyzer_v2"
+
+export class CircleciRunnerV2 implements Runner {
+  service: string = 'circleci'
+  client: CircleciClientV2
+  analyzer: CircleciAnalyzerV2
+  config: CircleciConfig | undefined
+  store?: LastRunStore
+  githubClient: GithubClient
+  logger: Logger
+
+  constructor(logger: Logger, public yamlConfig: YamlConfig, public options: ArgumentOptions) {
+    const CIRCLECI_TOKEN = process.env['CIRCLECI_TOKEN'] || ''
+    this.config = parseConfig(yamlConfig)
+    this.logger = logger.getChildLogger({ name: CircleciRunnerV2.name, instanceName: this.service })
+    this.client = new CircleciClientV2(CIRCLECI_TOKEN, this.logger, options, this.config?.baseUrl)
+    this.analyzer = new CircleciAnalyzerV2()
+
+    const GITHUB_TOKEN = process.env['GITHUB_TOKEN'] || ''
+    this.githubClient = new GithubClient(GITHUB_TOKEN, options, this.config?.vcsBaseUrl?.github)
+  }
+
+  async isHostAvailableVersion(): Promise<Result<unknown, Error>> {
+    return this.client.isHostAvailableVersion()
+  }
+
+  private setRepoLastRun(reponame: string, pipelines: Pipeline[]) {
+    const maxBuildNumber = max(pipelines.map((pipeline) => pipeline.number))
+    if (maxBuildNumber) {
+      this.store?.setLastRun(reponame, maxBuildNumber)
+    }
+  }
+
+  async run (): Promise<Result<unknown, Error>> {
+    let result: Result<unknown, Error> = success(this.service)
+    if (!this.config) return failure(new Error('this.config must not be undefined'))
+    this.store = await LastRunStore.init(this.logger, this.options, this.service, this.config.lastRunStore)
+
+    const workflowReports: WorkflowReport[] = []
+    const testReports: TestReport[] = []
+    const customReportCollection = new CustomReportCollection()
+    for (const repo of this.config.repos) {
+      this.logger.info(`Fetching ${this.service} - ${repo.fullname} ...`)
+
+      try {
+        const lastRunId = this.store.getLastRun(repo.fullname)
+        const pipelines = await this.client.fetchWorkflowRuns(repo.owner, repo.repo, repo.vcsType, lastRunId)
+
+        for (const pipeline of pipelines) {
+          const workflows = await this.client.fetchPipelineWorkflows(pipeline)
+          const tests = await this.client.fetchWorkflowsTests(workflows)
+
+          // Create report
+          const pipelineWorkflowReports = workflows.map((workflow) => this.analyzer.createWorkflowReport(pipeline, workflow))
+          const pipelineTestReports = await this.analyzer.createTestReports(pipelineWorkflowReports, tests)
+
+          // Aggregate
+          workflowReports.push(...pipelineWorkflowReports)
+          testReports.push(...pipelineTestReports)
+
+          // Custom Report
+          for (const workflow of workflows) {
+            const customReportArtifactsList = await this.client.fetchWorkflowCustomReports(workflow, repo.customReports)
+            const customReportArtifacts = aggregateCustomReportArtifacts(customReportArtifactsList)
+
+            const workflowReport = pipelineWorkflowReports.find((report) => workflow.name === report.workflowName )!
+            const runCustomReportCollection = await createCustomReportCollection(workflowReport, customReportArtifacts)
+
+            customReportCollection.aggregate(runCustomReportCollection)
+          }
+        }
+
+        this.setRepoLastRun(repo.fullname, pipelines)
+      }
+      catch (error) {
+        const errorMessage = `Some error raised in '${repo.fullname}', so it skipped.`
+        this.logger.error(errorMessage)
+        this.logger.error(error)
+        result = failure(new Error(errorMessage))
+        continue
+      }
+    }
+
+    this.logger.info(`Exporting ${this.service} workflow reports ...`)
+    const exporter = new CompositExporter(this.logger, this.options, this.service, this.config.exporter)
+    await exporter.exportWorkflowReports(workflowReports)
+    await exporter.exportTestReports(testReports)
+    await exporter.exportCustomReports(customReportCollection)
+
+    this.store.save()
+    this.logger.info(`Done execute '${this.service}'. status: ${result.type}`)
+
+    return result
+  }
+}


### PR DESCRIPTION
Support CircleCI API v2 🎉 
So CircleCI v1.1 does not provide API that about pipeline, previously CIAnalyzer reconstruct pipeline structure from each job.

Now, CIAnalyzer uses a pipeline data structure provided by API v2. The exported data will be closer to what you can see on the CircleCI website. 

## How to migrate from v1.1
After upgrade CIAnalzyer version newer than v4.2, do not need any changes in your config YAML if you want to still use CircleCI API v1.1 .

When you want to use CircleCI v2, you have to change the config as below.

```yaml
# before (use API v1.1)
baseUrl: https://circleci.com/api/v1.1

# after (use API v2)
baseUrl: https://circleci.com/api/ # Remove suffix "v1.1" from URL
version: 2 # Add
```

**NOTICE** The first time after you enable v2, CIAnalyzer reset the LastRun build number and will export the last 100 pipeline data. As a result, it may be exporting duplicate data that has already been exported before.
There is no workaround to avoid this problem, sorry.