### PR TITLE
fix(CircleCI): Bugfix cannot use API v2 when no CIRCLECI_TOKEN

### DIFF
--- a/src/client/circleci_client_v2.ts
+++ b/src/client/circleci_client_v2.ts
@@ -215,7 +215,12 @@ export class CircleciClientV2 {
 
   async isHostAvailableVersion(): Promise<Result<unknown, Error>> {
     try {
-      await this.axios.get( `v2/me`, {} )
+      await this.axios.get( `v2/me`, {
+        validateStatus: (status) => {
+          return (status >= 200 && status < 300) // default
+            || status === 401 // It means endpoint of API v2 is exists.
+        }
+      })
     } catch (error) {
       return failure(new Error(`${this.baseUrl} unavailable API v2`))
     }


### PR DESCRIPTION
If `CIRCLECI_TOKEN` is not set, you got the false error that the API is not supported, even if it is actually supported on the host.
This is a bug. So isHostAvailableVersion() should only check API v2 endpoint is exists or not, I fixed it.