### PR TITLE
Limit request concurrency

### DIFF
--- a/__tests__/client/jenkins_client.test.ts
+++ b/__tests__/client/jenkins_client.test.ts
@@ -1,32 +1,36 @@
 import { Logger } from 'tslog'
+import { ArgumentOptions } from '../../src/arg_options'
 import { JenkinsClient } from '../../src/client/jenkins_client'
 
 const logger = new Logger({ minLevel: "warn" })
+const options = new ArgumentOptions({
+  "c": "./dummy.yaml"
+})
 
 describe('JenkinsClient', () => {
   const baseUrl = 'http://localhost:8080'
   describe('new', () => {
     it('should not throw error when both user and token are undefined', async () => {
-      const client = new JenkinsClient(baseUrl, logger)
+      const client = new JenkinsClient(baseUrl, logger, options)
 
       expect(client).toBeTruthy()
     })
 
     it('should not throw error when both user and token are valid', async () => {
-      const client = new JenkinsClient(baseUrl, logger, 'user', 'token')
+      const client = new JenkinsClient(baseUrl, logger, options, 'user', 'token')
 
       expect(client).toBeTruthy()
     })
 
     it('should throw error when only user is undeinfed', async () => {
       expect(() => {
-        const client = new JenkinsClient(baseUrl, logger, undefined, 'token')
+        const client = new JenkinsClient(baseUrl, logger, options, undefined, 'token')
       }).toThrow()
     })
 
     it('should throw error when only token is undeinfed', async () => {
       expect(() => {
-        const client = new JenkinsClient(baseUrl, logger, 'usre', undefined)
+        const client = new JenkinsClient(baseUrl, logger, options, 'usre', undefined)
       }).toThrow()
     })
   })
@@ -50,28 +54,28 @@ describe('JenkinsClient', () => {
 
     let client: JenkinsClient
     beforeEach(() => {
-      client = new JenkinsClient(baseUrl, logger)
+      client = new JenkinsClient(baseUrl, logger, options)
     })
 
     it('when lastRunId is undef and has not in_pregress runs', async () => {
       const lastRunId = undefined
       const actual = client.filterJobRuns(allCompletedRuns, lastRunId)
 
-      expect(actual.map((run) => run.id)).toEqual(['2','3','4','5','6'])
+      expect(actual.map((run) => run.id)).toEqual(['2', '3', '4', '5', '6'])
     })
 
     it('when defined lastRunId and has not in_pregress runs', async () => {
       const lastRunId = 2
       const actual = client.filterJobRuns(allCompletedRuns, lastRunId)
 
-      expect(actual.map((run) => run.id)).toEqual(['3','4','5','6'])
+      expect(actual.map((run) => run.id)).toEqual(['3', '4', '5', '6'])
     })
 
     it('when lastRunId is undef and has in_pregress runs', async () => {
       const lastRunId = undefined
       const actual = client.filterJobRuns(hasInprogressRuns, lastRunId)
 
-      expect(actual.map((run) => run.id)).toEqual(['2','3'])
+      expect(actual.map((run) => run.id)).toEqual(['2', '3'])
     })
 
     it('when defined lastRunId and has in_pregress runs', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/minimatch": "3.0.5",
         "adm-zip": "0.5.9",
         "axios": "0.25.0",
+        "axios-concurrency": "1.0.4",
         "axios-retry": "3.2.4",
         "dayjs": "1.10.7",
         "js-yaml": "4.1.0",
@@ -1746,6 +1747,22 @@
       "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
       "dependencies": {
         "follow-redirects": "^1.14.7"
+      }
+    },
+    "node_modules/axios-concurrency": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/axios-concurrency/-/axios-concurrency-1.0.4.tgz",
+      "integrity": "sha512-KDtlv1uWln80fmr6D4aq2je/HAtiMZ6k3nY8uCbQlSQWHznpm2v3aZPlBatPBGUBWuDeFRpMF9aFFpO+xyiW4g==",
+      "dependencies": {
+        "axios": "^0.21.1"
+      }
+    },
+    "node_modules/axios-concurrency/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/axios-retry": {
@@ -6915,6 +6932,24 @@
       "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
       "requires": {
         "follow-redirects": "^1.14.7"
+      }
+    },
+    "axios-concurrency": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/axios-concurrency/-/axios-concurrency-1.0.4.tgz",
+      "integrity": "sha512-KDtlv1uWln80fmr6D4aq2je/HAtiMZ6k3nY8uCbQlSQWHznpm2v3aZPlBatPBGUBWuDeFRpMF9aFFpO+xyiW4g==",
+      "requires": {
+        "axios": "^0.21.1"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        }
       }
     },
     "axios-retry": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/minimatch": "3.0.5",
     "adm-zip": "0.5.9",
     "axios": "0.25.0",
+    "axios-concurrency": "1.0.4",
     "axios-retry": "3.2.4",
     "dayjs": "1.10.7",
     "js-yaml": "4.1.0",

--- a/src/@types/axios-concurrency.ts
+++ b/src/@types/axios-concurrency.ts
@@ -1,0 +1,8 @@
+declare module "axios-concurrency" {
+  import { Axios } from "axios"
+
+  export function ConcurrencyManager(axios: Axios, MAX_CONCURRENT?: number): Instance
+  type Instance = {
+    detach: () => void
+  }
+}

--- a/src/arg_options.ts
+++ b/src/arg_options.ts
@@ -12,6 +12,7 @@ export class ArgumentOptions {
   onlyExporters?: string[]
   logLevel: "debug" | "info"
   keepAlive: boolean
+  maxConcurrentRequests?: number
 
   constructor(argv: Argv) {
     this.configPath = path.resolve(argv['c'] as string)
@@ -21,5 +22,8 @@ export class ArgumentOptions {
     this.onlyExporters = argv['only-exporters'] as string[]
     this.logLevel = (argv['v'] as number > 0) ? 'debug' : 'info'
     this.keepAlive = argv['keepalive'] as boolean
+    this.maxConcurrentRequests = (argv['max-concurrent-requests'] as number > 0)
+      ? argv['max-concurrent-requests'] as number
+      : undefined
   }
 }

--- a/src/arg_options.ts
+++ b/src/arg_options.ts
@@ -11,6 +11,7 @@ export class ArgumentOptions {
   configDir: string
   onlyExporters?: string[]
   logLevel: "debug" | "info"
+  keepAlive: boolean
 
   constructor(argv: Argv) {
     this.configPath = path.resolve(argv['c'] as string)
@@ -19,5 +20,6 @@ export class ArgumentOptions {
     this.configDir = path.dirname(this.configPath)
     this.onlyExporters = argv['only-exporters'] as string[]
     this.logLevel = (argv['v'] as number > 0) ? 'debug' : 'info'
+    this.keepAlive = argv['keepalive'] as boolean
   }
 }

--- a/src/client/bitrise_client.ts
+++ b/src/client/bitrise_client.ts
@@ -103,12 +103,12 @@ export class BitriseClient {
   private artifactAxios: AxiosInstance
   constructor(token: string, logger: Logger, private options: ArgumentOptions, baseUrl?: string) {
     const axiosLogger = logger.getChildLogger({ name: BitriseClient.name })
-    this.axios = createAxios(axiosLogger, {
+    this.axios = createAxios(axiosLogger, options, {
       baseURL: baseUrl ?? 'https://api.bitrise.io/v0.1',
       headers: {'Authorization': token },
     })
 
-    this.artifactAxios = createAxios(axiosLogger, {})
+    this.artifactAxios = createAxios(axiosLogger, options, {})
   }
 
   // https://api-docs.bitrise.io/#/application/app-list

--- a/src/client/circleci_client.ts
+++ b/src/client/circleci_client.ts
@@ -118,7 +118,7 @@ export class CircleciClient {
       throw new Error(`${CircleciClient.name} accepts only "/api/v1.1/" But your baseUrl is ${baseUrl}`)
     }
     const axiosLogger = logger.getChildLogger({ name: CircleciClient.name })
-    this.axios = createAxios(axiosLogger, {
+    this.axios = createAxios(axiosLogger, options, {
       baseURL: baseUrl ?? 'https://circleci.com/api/v1.1',
       auth: {
         username: token,

--- a/src/client/circleci_client_v2.ts
+++ b/src/client/circleci_client_v2.ts
@@ -204,7 +204,7 @@ export class CircleciClientV2 {
     }
     const axiosLogger = logger.getChildLogger({ name: CircleciClientV2.name })
     this.baseUrl = baseUrl ?? 'https://circleci.com/api',
-    this.axios = createAxios(axiosLogger, {
+    this.axios = createAxios(axiosLogger, options, {
       baseURL: this.baseUrl,
       auth: {
         username: token,

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,7 +1,9 @@
 import axios, { AxiosRequestConfig } from 'axios'
 import axiosRetry from 'axios-retry'
-import path from 'path'
+import http from 'http'
+import https from 'https'
 import { Logger } from 'tslog'
+import { ArgumentOptions } from '../arg_options'
 
 export type Artifact = {
   path: string
@@ -10,10 +12,12 @@ export type Artifact = {
 
 export type CustomReportArtifact = Map<string, Artifact[]>
 
-export const createAxios = (logger: Logger, config: AxiosRequestConfig) => {
+export const createAxios = (logger: Logger, options: ArgumentOptions, config: AxiosRequestConfig) => {
   const axiosInstance = axios.create({
     // Default parameters
     timeout: 5000,
+    httpAgent: (options.keepAlive) ? new http.Agent({ keepAlive: true }) : undefined,
+    httpsAgent:(options.keepAlive) ? new https.Agent({ keepAlive: true }) : undefined,
 
     // Overwrite parameters
     ...config

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosRequestConfig } from 'axios'
 import axiosRetry from 'axios-retry'
+import { ConcurrencyManager } from 'axios-concurrency'
 import http from 'http'
 import https from 'https'
 import { Logger } from 'tslog'
@@ -55,6 +56,11 @@ export const createAxios = (logger: Logger, options: ArgumentOptions, config: Ax
       }
     return Promise.reject(error)
   })
+
+  if (options.maxConcurrentRequests) {
+    ConcurrencyManager(axiosInstance, options.maxConcurrentRequests)
+  }
+
   return axiosInstance
 }
 

--- a/src/client/jenkins_client.ts
+++ b/src/client/jenkins_client.ts
@@ -4,6 +4,7 @@ import { minBy } from 'lodash'
 import minimatch from 'minimatch'
 import { CustomReportConfig } from '../config/config'
 import { Logger } from 'tslog'
+import { ArgumentOptions } from '../arg_options'
 
 // ref: https://github.com/jenkinsci/pipeline-stage-view-plugin/blob/master/rest-api/src/main/java/com/cloudbees/workflow/rest/external/StatusExt.java
 export type JenkinsStatus = 'SUCCESS' | 'FAILED' | 'ABORTED' | 'NOT_EXECUTED' | 'IN_PROGRESS' | 'PAUSED_PENDING_INPUT' | 'UNSTABLE'
@@ -171,7 +172,7 @@ export type TimeInQueueAction = {
 
 export class JenkinsClient {
   private axios: AxiosInstance
-  constructor(baseUrl: string, logger: Logger, user?: string, token?: string) {
+  constructor(baseUrl: string, logger: Logger, private options: ArgumentOptions, user?: string, token?: string) {
     if ((user && !token) || (!user && token)) throw new Error('Either $JENKSIN_USER or $JENKINS_TOKEN is undefined.')
 
     const auth = (user && token) ? {
@@ -180,7 +181,7 @@ export class JenkinsClient {
     } : undefined
 
     const axiosLogger = logger.getChildLogger({ name: JenkinsClient.name })
-    this.axios = createAxios(axiosLogger, {
+    this.axios = createAxios(axiosLogger, options, {
       baseURL: baseUrl,
       auth,
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ const main = async () => {
       'debug': { type: 'boolean', default: false, describe: 'Enable debug mode' },
       'only-services': { type: 'string', array: true, describe: 'Exec only selected services. ex: --only-services circleci github' },
       'only-exporters': { type: 'string', array: true, describe: 'Export data using only selected exporters. ex: --only-exporters local' },
+      'keepalive': { type: 'boolean', default: true, describe: 'Enable http/https keepalive' },
     })
     .strict()
     .argv

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ const main = async () => {
       'only-services': { type: 'string', array: true, describe: 'Exec only selected services. ex: --only-services circleci github' },
       'only-exporters': { type: 'string', array: true, describe: 'Export data using only selected exporters. ex: --only-exporters local' },
       'keepalive': { type: 'boolean', default: true, describe: 'Enable http/https keepalive' },
+      'max-concurrent-requests': { type: 'number', default: 10, describe: 'Limit http request concurrency per service. When set 0, disable concurrency limit' },
     })
     .strict()
     .argv

--- a/src/runner/jenkins_runner.ts
+++ b/src/runner/jenkins_runner.ts
@@ -28,7 +28,7 @@ export class JenkinsRunner implements Runner {
     const JENKINS_USER = process.env['JENKINS_USER']
     const JENKINS_TOKEN = process.env['JENKINS_TOKEN']
     this.analyzer = new JenkinsAnalyzer(this.config.baseUrl)
-    this.client = new JenkinsClient(this.config.baseUrl, this.logger, JENKINS_USER, JENKINS_TOKEN)
+    this.client = new JenkinsClient(this.config.baseUrl, this.logger, options, JENKINS_USER, JENKINS_TOKEN)
   }
 
   private setRepoLastRun(jobname: string, reports: WorkflowReport[]) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,7 +43,7 @@
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    "typeRoots": ["src/@types", "node_modules/@types"],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
@@ -66,5 +66,10 @@
   },
   "include": [
     "src/**/*"
-  ]
+  ],
+  "ts-node": {
+    "transpileOnly": true,
+    // Enable to find own @types
+    "files": true,
+  }
 }


### PR DESCRIPTION
I found CIAnalyzer sometimes creates too many request connections and these may reject by the network layer. I faced this problem in my Jenkins that using GCP Cloud NAT.

Some methods create requests concurrently. If using `correctAllJobs` option in Jenkins config, concurrent request number is reached same as **registered job number in Jenkins**. 

**BREAKING CHANGES**

To handle this problem, use keepalive and limit the number of concurrent requests. Both behaviors are set in default, but these can disable through `--keepalive` and `--max-concurrent-requests`. 