### PR TITLE
Fix Jenkins API error response handling

### DIFF
--- a/src/client/jenkins_client.ts
+++ b/src/client/jenkins_client.ts
@@ -203,13 +203,20 @@ export class JenkinsClient {
 
   async fetchJobRuns(jobName: string, lastRunId?: number) {
     const url = encodeURI(`job/${jobName}/wfapi/runs`)
-    const res = await this.axios.get(url, {
-      params: {
-        fullStages: "true"
-      }
-    })
+    let runs: WfapiRunResponse[]
+    try {
+      const res = await this.axios.get(url, {
+        params: {
+          fullStages: "true"
+        }
+      })
+      runs = res.data
+    }
+    // Sometimes wfapi/runs return 500.
+    // However if that job comes from `correctAllJobs` config option, user may not do anything.
+    // To handle this situation, catch the error and return empty array.
+    catch { return [] }
 
-    const runs = res.data as WfapiRunResponse[]
     return this.filterJobRuns(runs, lastRunId)
   }
 

--- a/src/runner/jenkins_runner.ts
+++ b/src/runner/jenkins_runner.ts
@@ -59,6 +59,11 @@ export class JenkinsRunner implements Runner {
         const lastRunId = this.store.getLastRun(job.name)
         const runs = await this.client.fetchJobRuns(job.name, lastRunId)
 
+        if (runs.length < 1) {
+          this.logger.warn(`SKIP ${job.name}: it does not have any runs data for some reason`)
+          continue
+        }
+
         for (const run of runs) {
           // Fetch data
           const build = await this.client.fetchBuild(job.name, Number(run.id))

--- a/src/runner/jenkins_runner.ts
+++ b/src/runner/jenkins_runner.ts
@@ -118,7 +118,7 @@ export class JenkinsRunner implements Runner {
           jobName: job.name,
           resultPromise: this.client!.fetchLastBuild(job.name)
             .then((res) => success(res))
-            .catch((error) => failure(error))
+            .catch((error) => Promise.resolve(failure(error)))
         }
       })
 
@@ -129,7 +129,7 @@ export class JenkinsRunner implements Runner {
       for (const { jobName, resultPromise } of buildRespones) {
         const result = await resultPromise
         if (result.isFailure()) {
-          this.logger.debug(`Skip ${jobName}: can not fetch lastBuild.`)
+          this.logger.warn(`SKIP ${jobName}: Can not fetch lastBuild number.`)
           continue
         }
 


### PR DESCRIPTION
Handle these Jenkins API error responses and just skip that jobs to prevent CIAnalzer exit code 0

- `job/$jobName/lastBuild/api/json`
- `job/$jobName/wfapi/runs`