### PR TITLE
fix(Bitrise): Handle error build that aborted rolling build

### DIFF
--- a/src/analyzer/bitrise_analyzer.ts
+++ b/src/analyzer/bitrise_analyzer.ts
@@ -78,7 +78,7 @@ export class BitriseAnalyzer implements Analyzer {
     }
   }
 
-  createWorkflowReport(app: App, build: BuildResponse, buildLog: BuildLogResponse): WorkflowReport {
+  createWorkflowReport(app: App, build: BuildResponse, buildLog: BuildLogResponse | null): WorkflowReport {
     const { workflowId, workflowRunId, buildNumber, workflowName }
       = this.createWorkflowParams(app, build)
     const createdAt = new Date(build.triggered_at)
@@ -175,7 +175,9 @@ export class BitriseAnalyzer implements Analyzer {
     return steps
   }
 
-  createStepReports(startedAt: Date, buildLog: BuildLogResponse): StepReport[] {
+  createStepReports(startedAt: Date, buildLog: BuildLogResponse | null): StepReport[] {
+    if (!buildLog) return []
+
     const steps = this.parseBuildLog(buildLog)
     let stepSumMilisec = 0
     return steps.map((step, index) => {

--- a/src/client/bitrise_client.ts
+++ b/src/client/bitrise_client.ts
@@ -158,8 +158,12 @@ export class BitriseClient {
   }
 
   // https://api-docs.bitrise.io/#/builds/build-log
-  async fetchJobLog(appSlug: string, buildSlug: string) {
-    const res = await this.axios.get( `apps/${appSlug}/builds/${buildSlug}/log`, {})
+  async fetchJobLog(appSlug: string, buildSlug: string): Promise<BuildLogResponse | null>  {
+    const res = await this.axios.get(`apps/${appSlug}/builds/${buildSlug}/log`, {
+      // NOTE: Allow 404 response build that aborted by rolling build and has not build log
+      validateStatus: (status) => (status >= 200 && status < 300) || status === 404
+    })
+    if (res.status === 404) return null
     return res.data as BuildLogResponse
   }
 


### PR DESCRIPTION
fix #518 

CIAnalyzer can fetch builds that have not build log and won't be stopped by build log API 404 response now.

As mentioned by @takeya0x86 If you enable Bitrise rolling build config and when queued builds are aborted by rolling build, these have no build log and API response 404. 