### PR TITLE
chore: Improve jest test time with isolateModules option

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,4 +13,10 @@ module.exports = {
   ],
   testEnvironment: 'node',
   clearMocks: true,
+  // https://kulshekhar.github.io/ts-jest/docs/getting-started/options/isolatedModules
+  globals: {
+    'ts-jest': {
+      isolatedModules: true,
+    },
+  },
 };


### PR DESCRIPTION
see: https://kulshekhar.github.io/ts-jest/docs/getting-started/options/isolatedModules

It makes faster about 2-3x at my Codespace and 1.6x at Github Actions.

before: https://github.com/Kesin11/CIAnalyzer/runs/6973028988?check_suite_focus=true

> Test Suites: 19 passed, 19 total
> Tests:       128 passed, 128 total
> Snapshots:   0 total
> Time:        12.152 s

after: https://github.com/Kesin11/CIAnalyzer/runs/6981208435?check_suite_focus=true

> Test Suites: 19 passed, 19 total
> Tests:       128 passed, 128 total
> Snapshots:   0 total
> Time:        7.505 s
> Ran all test suites.