### PR TITLE
Enable ES2022 feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,9 @@
         "ts-proto": "1.117.0",
         "ts-protoc-gen": "0.15.0",
         "typescript": "4.7.4"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "url": "https://github.com/Kesin11/CIAnalyzer/issues"
   },
   "homepage": "https://github.com/Kesin11/CIAnalyzer#readme",
+  	"engines": {
+		"node": ">=16.0.0"
+	},
   "bin": {
     "ci_analyzer": "dist/index.js"
   },

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -15,7 +15,9 @@ export interface Runner {
 
 export class CompositRunner implements Runner {
   runners: Runner[]
-  constructor(private logger: Logger, public config: YamlConfig, public options: ArgumentOptions) {
+  #logger: Logger
+  constructor(logger: Logger, public config: YamlConfig, public options: ArgumentOptions) {
+    this.#logger = logger
     const services = options.onlyServices
       ? Object.keys(config).filter((service) => options.onlyServices?.includes(service))
       : Object.keys(config)
@@ -58,20 +60,20 @@ export class CompositRunner implements Runner {
 
   handlingError(error: unknown) {
     if (axios.isAxiosError(error)) {
-      this.logger.error(error.message)
-      this.logger.error(error.stack)
+      this.#logger.error(error.message)
+      this.#logger.error(error.stack)
     }
     else if (error instanceof ApiError) {
-      this.logger.error("Catch GCloud Error. Please check 'gcloud' auth status or your permission.")
-      this.logger.error(`${error.response?.body}`)
-      this.logger.error(error.stack)
+      this.#logger.error("Catch GCloud Error. Please check 'gcloud' auth status or your permission.")
+      this.#logger.error(`${error.response?.body}`)
+      this.#logger.error(error.stack)
     }
     else if (error instanceof Error) {
-      this.logger.error(error.message)
-      this.logger.error(error.stack)
+      this.#logger.error(error.message)
+      this.#logger.error(error.stack)
     }
     else {
-      this.logger.error(error)
+      this.#logger.error(error)
     }
   }
 }

--- a/src/store/null_store.ts
+++ b/src/store/null_store.ts
@@ -2,19 +2,19 @@ import { Logger } from 'tslog'
 import { Store, AnyObject } from './store'
 
 export class NullStore implements Store {
-  private logger: Logger
+  #logger: Logger
 
   constructor(logger: Logger) {
-    this.logger = logger.getChildLogger({ name: NullStore.name })
+    this.#logger = logger.getChildLogger({ name: NullStore.name })
   }
 
   async read<T extends AnyObject>(): Promise<T> {
-    this.logger.info(`Detect DEBUG mode, nothing is used instead.`)
+    this.#logger.info(`Detect DEBUG mode, nothing is used instead.`)
     return {} as T
   }
 
   async write<T extends AnyObject> (newStore: T): Promise<T> {
-    this.logger.info(`Detect DEBUG mode, skip saving lastRun.`)
+    this.#logger.info(`Detect DEBUG mode, skip saving lastRun.`)
     return {} as T
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     "incremental": true,                   /* Enable incremental compilation */
-    "target": "ES2019",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "ES2022",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     "lib": ["es2020"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
Require nodejs >= 16 to enable `target: ES2022` that need if using newer nodejs features.

First of all, replace TypeScript `private` to nodejs private field.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields
