### PR TITLE
Push release image tags from Earthly

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,7 @@ jobs:
         id: docker_meta
         with:
           images: ghcr.io/kesin11/ci_analyzer
+          sep-tags: ","
           tags: |
             type=ref,event=branch
             type=semver,pattern=v{{version}}
@@ -33,11 +34,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker build and push latest tag
-        run: earthly --strict --push --max-remote-cache --remote-cache=ghcr.io/kesin11/ci_analyzer_earthly:cache +docker
-
-      - name: Copy latest tag to other tags
-        uses: akhilerm/tag-push-action@v2.0.0
-        with:
-          src: ghcr.io/kesin11/ci_analyzer_earthly:latest
-          dst: |
-            ${{ steps.docker_meta.outputs.tags }}
+        run: |
+          TAGS=$(echo "${{ steps.docker_meta.outputs.tags }}" | tr ',' ' ')
+          earthly --strict --push --max-remote-cache \
+            --remote-cache=ghcr.io/kesin11/ci_analyzer_earthly:cache \
+            +docker-push \
+            --TAGS "${TAGS}"

--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.5
+VERSION 0.6
 
 # TypeScript build
 FROM node:16.17.0
@@ -63,4 +63,12 @@ docker:
   ENTRYPOINT [ "/sbin/tini", "--", "node", "/ci_analyzer/dist/index.js" ]
   WORKDIR /app
 
-  SAVE IMAGE --push ghcr.io/kesin11/ci_analyzer_earthly:latest
+  SAVE IMAGE ghcr.io/kesin11/ci_analyzer:latest
+
+docker-push:
+  FROM +docker
+  ARG --required TAGS
+
+  FOR TAG IN $TAGS
+    SAVE IMAGE --push $TAG
+  END


### PR DESCRIPTION
Previously, use akhilerm/tag-push-action for pushing versioned image tags(e.g. v5, v5.0, v5.0.0),
Earthly can push multiple tags directly using new `FOR` syntax from v0.6. So it will no need to push `ghcr.io/kesin11/ci_analyzer_earthly`  and using tag-push-action.