### PR TITLE
chore(ci): Re enable ts-jest isolatedModules option

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  preset: 'ts-jest',
   reporters: [
     'default',
     [ 'jest-junit', {
@@ -14,9 +13,7 @@ module.exports = {
   testEnvironment: 'node',
   clearMocks: true,
   // https://kulshekhar.github.io/ts-jest/docs/getting-started/options/isolatedModules
-  globals: {
-    'ts-jest': {
-      isolatedModules: true,
-    },
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { isolatedModules: true }]
   },
 };


### PR DESCRIPTION
ts-jest v29 deprecate to set options in `globals` and change to use `transform`. This change also affected `ts-jest` preset.
https://github.com/kulshekhar/ts-jest/pull/3780
As a result, `isolatedModules` that set in `globals` is ignored and the test run time has increased compared to v28.

[It seems possible to set `isolatedModules` option with preset](https://kulshekhar.github.io/ts-jest/docs/getting-started/presets), but it is more complicated than with `globals` in v28. So I config `transform` manually instead of using  `preset: 'ts-jest'`.