### PR TITLE
fix(Github): Bugfix Collecting invalid run data when some job are queued

### DIFF
--- a/__tests__/client/github_client.test.ts
+++ b/__tests__/client/github_client.test.ts
@@ -17,6 +17,14 @@ const hasInprogressRuns = [
   { run_number: 6, status: 'completed' },
 ] as any
 
+const hasQueuedRuns = [
+  { run_number: 2, status: 'completed' },
+  { run_number: 3, status: 'completed' },
+  { run_number: 4, status: 'queued' },
+  { run_number: 5, status: 'queued' },
+  { run_number: 6, status: 'completed' },
+] as any
+
 describe('GithubClient', () => {
   describe('filterWorkflowRuns', () => {
     let client: GithubClient
@@ -51,6 +59,20 @@ describe('GithubClient', () => {
     it('when defined lastRunId and has in_pregress runs', async () => {
       const lastRunId = 2
       const actual = client.filterWorkflowRuns(hasInprogressRuns, lastRunId)
+
+      expect(actual.map((run) => run.run_number)).toEqual([3])
+    })
+
+    it('when lastRunId is undef and has queued runs', async () => {
+      const lastRunId = undefined
+      const actual = client.filterWorkflowRuns(hasQueuedRuns, lastRunId)
+
+      expect(actual.map((run) => run.run_number)).toEqual([2,3])
+    })
+
+    it('when defined lastRunId and has queued runs', async () => {
+      const lastRunId = 2
+      const actual = client.filterWorkflowRuns(hasQueuedRuns, lastRunId)
 
       expect(actual.map((run) => run.run_number)).toEqual([3])
     })

--- a/src/client/github_client.ts
+++ b/src/client/github_client.ts
@@ -66,7 +66,7 @@ export class GithubClient {
       ? runs.filter((run) => run.run_number > lastRunId)
       : runs
     const firstInprogress = minBy(
-      runs.filter((run) => run.status as RunStatus === 'in_progress'),
+      runs.filter((run) => run.status as RunStatus !== 'completed'),
       (run) => run.run_number
     )
     runs = (firstInprogress)


### PR DESCRIPTION
Previously, GitHub Actions run data that still `queued` status were collected accidentaly.

Collected data were invalid because CIAnalyzer expect fetched run data status are "completed".
To fix it, filter accept status only "completed".