### PR TITLE
chore(ci): Bump earthly/actions-setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: earthly/actions-setup@v1
+      - uses: earthly/actions-setup@v1.0.2
         with:
           version: latest
       - name: Generate files
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: earthly/actions-setup@v1
+      - uses: earthly/actions-setup@v1.0.2
         with:
           version: latest
       - name: Docker build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: earthly/actions-setup@v1
+      - uses: earthly/actions-setup@v1.0.2
         with:
           version: latest
       - uses: docker/metadata-action@v4


### PR DESCRIPTION
If use earthly/actions-setup@v1 reported these warning. Current v1.0.2 uses node16 so we pinned that version.

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: earthly/actions-setup@v1
```