### PR TITLE
Fix tslog style

### DIFF
--- a/__tests__/client/circleci_client.test.ts
+++ b/__tests__/client/circleci_client.test.ts
@@ -2,7 +2,7 @@ import { Logger } from 'tslog'
 import { ArgumentOptions } from '../../src/arg_options'
 import { CircleciClient } from '../../src/client/circleci_client'
 
-const logger = new Logger({ minLevel: 'warn' })
+const logger = new Logger({ type: "hidden" })
 const options = new ArgumentOptions({
   "c": "./dummy.yaml"
 })

--- a/__tests__/client/circleci_client_v2.test.ts
+++ b/__tests__/client/circleci_client_v2.test.ts
@@ -2,7 +2,7 @@ import { Logger } from 'tslog'
 import { ArgumentOptions } from '../../src/arg_options'
 import { CircleciClientV2 } from '../../src/client/circleci_client_v2'
 
-const logger = new Logger({ minLevel: 'warn' })
+const logger = new Logger({ type: "hidden" })
 const options = new ArgumentOptions({
   "c": "./dummy.yaml"
 })

--- a/__tests__/client/jenkins_client.test.ts
+++ b/__tests__/client/jenkins_client.test.ts
@@ -2,7 +2,7 @@ import { Logger } from 'tslog'
 import { ArgumentOptions } from '../../src/arg_options'
 import { JenkinsClient } from '../../src/client/jenkins_client'
 
-const logger = new Logger({ minLevel: "warn" })
+const logger = new Logger({ type: "hidden" })
 const options = new ArgumentOptions({
   "c": "./dummy.yaml"
 })

--- a/__tests__/exporter/bigquery_exporter.test.ts
+++ b/__tests__/exporter/bigquery_exporter.test.ts
@@ -13,7 +13,7 @@ const configDir = path.join(__dirname, '..', '..')
 const fixtureSchemaPath = {
   custom: './__tests__/fixture/custom_table.json'
 }
-const logger = new Logger({ minLevel: 'warn' })
+const logger = new Logger({ type: "hidden" })
 
 describe('BigqueryExporter', () => {
   const workflowTable = 'workflow'

--- a/__tests__/exporter/local_exporter.test.ts
+++ b/__tests__/exporter/local_exporter.test.ts
@@ -7,7 +7,7 @@ const mockFsPromises = {
   mkdir: jest.fn(),
   writeFile: jest.fn(),
 }
-const logger = new Logger({ minLevel: 'warn' })
+const logger = new Logger({ type: "hidden" })
 
 describe('LocalExporter', () => {
   describe('new', () => {

--- a/__tests__/runner/circleci_runner_v1.test.ts
+++ b/__tests__/runner/circleci_runner_v1.test.ts
@@ -4,7 +4,7 @@ import { ArgumentOptions } from '../../src/arg_options'
 import { LastRunStore } from '../../src/last_run_store'
 import { NullStore } from '../../src/store/null_store'
 
-const logger = new Logger({ minLevel: 'warn' })
+const logger = new Logger({ type: "hidden" })
 const argOptions = new ArgumentOptions({
   c: 'cianalyzer.yml',
   v: 0,

--- a/__tests__/runner/circleci_runner_v2.test.ts
+++ b/__tests__/runner/circleci_runner_v2.test.ts
@@ -4,7 +4,7 @@ import { ArgumentOptions } from '../../src/arg_options'
 import { LastRunStore } from '../../src/last_run_store'
 import { NullStore } from '../../src/store/null_store'
 
-const logger = new Logger({ minLevel: 'warn' })
+const logger = new Logger({ type: "hidden" })
 const argOptions = new ArgumentOptions({
   c: 'cianalyzer.yml',
   v: 0,

--- a/__tests__/store/local_store.test.ts
+++ b/__tests__/store/local_store.test.ts
@@ -6,7 +6,7 @@ import crypto from 'crypto'
 import { Logger } from 'tslog'
 
 const createRandomStr = () => crypto.randomBytes(8).toString('hex')
-const logger = new Logger({ minLevel: 'warn' })
+const logger = new Logger({ type: "hidden" })
 
 describe('LocalStore', () => {
   const repo = 'owner/repo'

--- a/__tests__/store/null_store.test.ts
+++ b/__tests__/store/null_store.test.ts
@@ -1,7 +1,7 @@
 import { Logger } from 'tslog'
 import { NullStore } from '../../src/store/null_store'
 
-const logger = new Logger({ minLevel: 'warn' })
+const logger = new Logger({ type: "hidden" })
 
 describe('LocalStore', () => {
   let store: NullStore

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,10 +25,10 @@ const main = async () => {
   const argOptions = new ArgumentOptions(argv)
   const logger = new Logger({
     minLevel: argOptions.logLevel,
-    prettyLogTemplate: "{{logLevelName}}\t{{name}}",
+    prettyLogTemplate: "{{logLevelName}}\t[{{name}}]",
     prettyLogStyles: {
       ...baseLoggerForStyles.settings.prettyLogStyles,
-      name: "black"
+      name: "whiteBright"
     }
   })
 


### PR DESCRIPTION
ref: https://github.com/Kesin11/CIAnalyzer/pull/699

I found part of log string that tslog `name` property does not shown at black background terminal, so back to white.
And migrate tslog config in test code.
