### PR TITLE
bugfix move zod-to-json-schemato prod module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "tslog": "4.8.2",
         "utility-types": "3.10.0",
         "yargs": "17.7.2",
-        "zod": "3.21.4"
+        "zod": "3.21.4",
+        "zod-to-json-schema": "3.21.1"
       },
       "bin": {
         "ci_analyzer": "dist/index.js"
@@ -44,8 +45,7 @@
         "ts-jest": "29.1.0",
         "ts-proto": "1.149.0",
         "ts-protoc-gen": "0.15.0",
-        "typescript": "5.1.3",
-        "zod-to-json-schema": "3.21.1"
+        "typescript": "5.1.3"
       },
       "engines": {
         "node": ">=v18.16.0"
@@ -5182,7 +5182,6 @@
       "version": "3.21.1",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.21.1.tgz",
       "integrity": "sha512-y5g0MPxDq+YG/T+cHGPYH4PcBpyCqwK6wxeJ76MR563y0gk/14HKfebq8xHiItY7lkc9GDFygCnkvNDTvAhYAg==",
-      "dev": true,
       "peerDependencies": {
         "zod": "^3.21.4"
       }
@@ -9140,7 +9139,6 @@
       "version": "3.21.1",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.21.1.tgz",
       "integrity": "sha512-y5g0MPxDq+YG/T+cHGPYH4PcBpyCqwK6wxeJ76MR563y0gk/14HKfebq8xHiItY7lkc9GDFygCnkvNDTvAhYAg==",
-      "dev": true,
       "requires": {}
     }
   }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "tslog": "4.8.2",
     "utility-types": "3.10.0",
     "yargs": "17.7.2",
-    "zod": "3.21.4"
+    "zod": "3.21.4",
+    "zod-to-json-schema": "3.21.1"
   },
   "devDependencies": {
     "@types/adm-zip": "0.5.0",
@@ -68,7 +69,6 @@
     "ts-jest": "29.1.0",
     "ts-proto": "1.149.0",
     "ts-protoc-gen": "0.15.0",
-    "typescript": "5.1.3",
-    "zod-to-json-schema": "3.21.1"
+    "typescript": "5.1.3"
   }
 }


### PR DESCRIPTION
Degraded by https://github.com/Kesin11/CIAnalyzer/pull/891

```
$ docker run ghcr.io/kesin11/ci_analyzer:master
node:internal/modules/cjs/loader:1078
  throw err;
  ^

Error: Cannot find module 'zod-to-json-schema'
Require stack:
- /ci_analyzer/dist/config/config.js
- /ci_analyzer/dist/index.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
    at Module._load (node:internal/modules/cjs/loader:920:27)
    at Module.require (node:internal/modules/cjs/loader:1141:19)
    at require (node:internal/modules/cjs/helpers:110:18)
    at Object.<anonymous> (/ci_analyzer/dist/config/config.js:10:46)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Module.require (node:internal/modules/cjs/loader:1141:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/ci_analyzer/dist/config/config.js',
    '/ci_analyzer/dist/index.js'
  ]
}

Node.js v18.16.0
```

This pull-request fix this issue.
