### PR TITLE
Bugfix ignore auto generated workflow(e.g. CodeQL)

### DIFF
--- a/__tests__/client/github_client.test.ts
+++ b/__tests__/client/github_client.test.ts
@@ -77,4 +77,39 @@ describe('GithubClient', () => {
       expect(actual.map((run) => run.run_number)).toEqual([3])
     })
   })
+
+  describe('filterWorkflows', () => {
+    let client: GithubClient
+    const options = new ArgumentOptions({
+      "c": "./dummy.yaml"
+    })
+    beforeEach(() => {
+      client = new GithubClient('DUMMY_TOKEN', options)
+    })
+
+    it('when workflows have CodeQL workflow', async () => {
+      const workflows = [
+        { name: "Release", "path": ".github/workflows/release.yml" },
+        { name: "CodeQL", "path": "dynamic/github-code-scanning/codeql" }
+      ] as any
+      const actual = client.filterWorkflows(workflows)
+
+      expect(actual).toStrictEqual([
+        { name: "Release", "path": ".github/workflows/release.yml" },
+      ])
+    })
+
+    it('when all workflows are user generated', async () => {
+      const workflows = [
+        { name: "Release", "path": ".github/workflows/release.yml" },
+        { name: "Test", "path": ".github/workflows/test.yml" }
+      ] as any
+      const actual = client.filterWorkflows(workflows)
+
+      expect(actual).toStrictEqual([
+        { name: "Release", "path": ".github/workflows/release.yml" },
+        { name: "Test", "path": ".github/workflows/test.yml" }
+      ])
+    })
+  })
 })

--- a/src/client/github_client.ts
+++ b/src/client/github_client.ts
@@ -82,9 +82,13 @@ export class GithubClient {
       repo,
     })
 
-    return workflows.data.workflows
+    return this.filterWorkflows(workflows.data.workflows)
   }
 
+  // Ignore auto generated workflows (e.g. CodeQL)
+  filterWorkflows (workflows: WorkflowItem[]): WorkflowItem[] {
+    return workflows.filter((workflow) => workflow.path.startsWith('.github/workflows/'))
+  }
 
   // see: https://developer.github.com/v3/actions/workflow-jobs/#list-jobs-for-a-workflow-run
   async fetchJobs(owner: string, repo: string, runId: number) {


### PR DESCRIPTION
When repository enables CodeQL default workflow, sometimes CIAnalyzer throws an error and could not complete.
To handle this issue easily, CIAnalyzer will only handle user generated workflows that paths are `.github/workflows/*`.