### PR TITLE
chore(docs): Update GitHub Actions sample using OIDC

### DIFF
--- a/sample/README.md
+++ b/sample/README.md
@@ -2,6 +2,17 @@
 You can use any service or environment that supports Docker to execute CIAnalyzer.  
 It is nice to you starting with these samples.
 
+## GitHub Actions
+[GitHub Actions workflow](./github_cron.yml)
+
+Sample config:
+
+- Export to BigQuery and Local file.
+- Store LastRun files to GCS.
+
+GitHub Actions is the most popular CI and can execute job with schedule using `cron` trigger.
+GitHub Actions [supports OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect), which is recommended over using the GCP service account secret. Since [`google-github-actions/auth`](https://github.com/google-github-actions/auth) automatically sets the `GOOGLE_APPLICATION_CREDENTIALS` environment variable, no special action is required in the CIAnalyzer configuration.
+
 ## CircleCi
 [CircleCI config file](./circleci_cron.yml)
 
@@ -25,13 +36,3 @@ Jenkins can choose cleaning workspace before every build or not. So If you choos
 But in some cases it does not work well. If you allow to run a job with multiple nodes, it is difficult to share LastRun files across each node. 
 
 To resolve this problem, using a GCS backend is recommended. It read/write LastRun files from/to GCS. As a result, LastRun files are shared with each build and each node.
-
-## GitHub Actions
-[GitHub Actions workflow](./github_cron.yml)
-
-Sample config:
-
-- Export to BigQuery and Local file.
-- Store LastRun files to GCS.
-
-It is the almost same configuration as Jenkins sample. Instead of using Jenkins credentials, restore GCP service account key from Github Actions secret and set it to `GOOGLE_APPLICATION_CREDENTIALS` env.

--- a/sample/github_cron.yml
+++ b/sample/github_cron.yml
@@ -6,6 +6,10 @@ on:
   - cron:  '0 * * * *'
 concurrency: cianalyzer
 
+permissions:
+  contents: 'read'
+  id-token: 'write'
+
 jobs:
   run:
     runs-on: ubuntu-latest
@@ -14,19 +18,19 @@ jobs:
     timeout-minutes: 20
     steps:
       # Checkout your repository that contains your config file.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          workload_identity_provider: 'projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/my-provider'
+          service_account: 'my-service-account@my-project.iam.gserviceaccount.com'
 
-      - name: Restore service account json
-        run: echo $SERVICE_ACCOUNT > service_account.json
-        env:
-          SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       - name: Run CIAnalyzer
         run: ci_analyzer -c ./ci_analyzer.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.YOUR_GITHUB_PAT }}
           CIRCLECI_TOKEN: ${{ secrets.YOUR_CIRCLECI_TOKEN }}
-          GOOGLE_APPLICATION_CREDENTIALS: service_account.json
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
           name: local_exporter output file


### PR DESCRIPTION
Update GitHub Actions sample using OIDC instead of service account secrets.

See also:

- https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect
- https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-google-cloud-platform