### PR TITLE
Bugfix CircleCI v2 throw error when fetching approval job

### DIFF
--- a/src/client/circleci_client_v2.ts
+++ b/src/client/circleci_client_v2.ts
@@ -306,10 +306,11 @@ export class CircleciClientV2 {
     const workflows: Workflow[] = []
     for (const workflow of pipeline.workflows) {
       const jobResponses = await this.fetchWorkflowJobs(workflow.id)
-      // Filter jobs that has not job_number
+      // Filter jobs that this.fetchJob will be failed
       const filterdWorkflowJobs = jobResponses.filter((jobResponse) => {
         return jobResponse.status !== "blocked"
-          && jobResponse.job_number !== undefined
+            && jobResponse.job_number !== undefined
+            && jobResponse.type !== "approval"
       }) as FilteredWorkflowJob[]
 
       // Fetch jobDetail and steps in parallel and then Combine to job


### PR DESCRIPTION
fix: https://github.com/Kesin11/CIAnalyzer/issues/1120

CircleCI [job detail API](https://circleci.com/docs/api/v2/index.html#operation/getJobDetails) will fail with 404 when trying to fetch an approval job.
Previously CIAnalyzer would throw an error and stop when fetching this type of job. This PR fixes this problem by ignoring the approval job.

```bash
# Show workflow jobs that include approval job (job_number: 11257)
$ curl -sS -u "$CIRCLECI_TOKEN:" https://circleci.com/api/v2/workflow/e3beb02d-56b1-4756-8c4b-3e1142abf0f9/job
{
  "next_page_token" : null,
  "items" : [ {
    "dependencies" : [ ],
    "job_number" : 11256,
    "id" : "49edd5ca-f340-46fa-9457-7b3621f3bb3a",
    "started_at" : "2024-03-11T14:56:45Z",
    "name" : "lint",
    "project_slug" : "gh/Kesin11/CIAnalyzer",
    "status" : "success",
    "type" : "build",
    "stopped_at" : "2024-03-11T14:56:59Z"
  }, {
    "dependencies" : [ ],
    "job_number" : 11257,
    "id" : "130074c4-6d17-464b-a517-1e6089cbd89d",
    "started_at" : "2024-03-11T14:56:43Z",
    "name" : "hold",
    "approved_by" : "c0b37cd5-9ac5-4bae-b701-c71026c0ed5a",
    "project_slug" : "gh/Kesin11/CIAnalyzer",
    "status" : "success",
    "type" : "approval",
    "stopped_at" : "2024-03-11T14:57:08Z",
    "approval_request_id" : "130074c4-6d17-464b-a517-1e6089cbd89d"
  }, {
    "dependencies" : [ "130074c4-6d17-464b-a517-1e6089cbd89d", "49edd5ca-f340-46fa-9457-7b3621f3bb3a" ],
    "job_number" : 11259,
    "id" : "bec90601-96ae-4d4c-a3d3-0bed583a503a",
    "started_at" : "2024-03-11T14:57:12Z",
    "name" : "build_and_test",
    "project_slug" : "gh/Kesin11/CIAnalyzer",
    "status" : "success",
    "type" : "build",
    "stopped_at" : "2024-03-11T14:58:00Z"
  } ]

# API response is 404
$ curl -sS -u "$CIRCLECI_TOKEN:" https://circleci.com/api/v2/project/github/Kesin11/CIAnalyzer/job/11257
{
    "message": "Job not found."
}
```