### PR TITLE
Biome formatter ignore package.json

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -29,7 +29,8 @@
       // Test fixtures
       "__tests__/fixtures/**",
       // Others
-      "tsconfig.json"
+      "tsconfig.json",
+      "package.json"
     ]
   },
   "overrides": [


### PR DESCRIPTION
package.json is rewritten by 'npm version', so it conficts with biome formatter.