### PR TITLE
set per_page 100 for GitHub fetchWorkflows

### DIFF
--- a/src/client/github_client.ts
+++ b/src/client/github_client.ts
@@ -94,6 +94,7 @@ export class GithubClient {
     const workflows = await this.#octokit.actions.listRepoWorkflows({
       owner,
       repo,
+      per_page: 100,
     });
 
     return this.filterWorkflows(workflows.data.workflows);


### PR DESCRIPTION
Hi, Kesin11. I think CIAnalyzer is great tool and want use it in my work.
Firstly I appreciate that you make it!!

## background
- We use Monorepo. Therefore many workflows exist.

## What I did
- set per_page 100 for GitHub fetchWorkflows
  - Number of per_page is 30 default. Sometimes big repository has more workflows.