### PR TITLE
Add `queuedDurationSec` for job

### DIFF
--- a/bigquery_schema/workflow_report.json
+++ b/bigquery_schema/workflow_report.json
@@ -202,6 +202,11 @@
     "name": "executorName",
     "type": "STRING",
     "mode": "NULLABLE"
+   },
+   {
+    "name": "queuedDurationSec",
+    "type": "FLOAT",
+    "mode": "NULLABLE"
    }
   ]
  },

--- a/proto/workflow.proto
+++ b/proto/workflow.proto
@@ -60,6 +60,7 @@ message PbJobReport {
   string executorClass = 12;
   string executorType = 13;
   string executorName = 14;
+  float queuedDurationSec = 15;
 }
 
 message PbStepReport {

--- a/src/analyzer/bitrise_analyzer.ts
+++ b/src/analyzer/bitrise_analyzer.ts
@@ -58,6 +58,7 @@ type JobReport = {
   executorClass: string; // "standard"
   executorType: string; // osx-vs4mac-stable
   executorName: ""; // Bitrise does not support self-hosted runner
+  queuedDurationSec: 0; // BitriseAnalyzer does not support job queued duration yet
 };
 
 type StepReport = {
@@ -134,6 +135,7 @@ export class BitriseAnalyzer implements Analyzer {
           executorClass: build.machine_type_id,
           executorType: build.stack_identifier,
           executorName: "",
+          queuedDurationSec: 0, // Not supported yet
         },
       ],
       startedAt,

--- a/src/analyzer/circleci_analyzer.ts
+++ b/src/analyzer/circleci_analyzer.ts
@@ -59,6 +59,7 @@ export type JobReport = {
   executorClass: ""; // CircleCIAnalyzer(v1) does not support
   executorType: ""; // CircleCIAnalyzer(v1) does not support
   executorName: ""; // CircleCIAnalyzer(v1) does not support
+  queuedDurationSec: 0; // CircleciAnalyzer(v1) does not support
 };
 
 type StepReport = {
@@ -142,6 +143,7 @@ export class CircleciAnalyzer implements Analyzer {
         executorClass: "",
         executorType: "",
         executorName: "",
+        queuedDurationSec: 0, // Not supported yet
       };
     });
 

--- a/src/analyzer/circleci_analyzer_v2.ts
+++ b/src/analyzer/circleci_analyzer_v2.ts
@@ -55,6 +55,7 @@ type JobReport = {
   executorClass: string; // medium
   executorType: string; // docker
   executorName: ""; // CircleCI does not support self-hosted runner
+  queuedDurationSec: 0; // CircleciAnalyzerV2 does not support job queued duration yet
 };
 
 type StepReport = {
@@ -139,6 +140,7 @@ export class CircleciAnalyzerV2 implements Analyzer {
         executorClass: job.detail.executor.resource_class,
         executorType: job.detail.executor.type,
         executorName: "",
+        queuedDurationSec: 0, // Not supported yet
       };
     });
 

--- a/src/analyzer/jenkins_analyzer.ts
+++ b/src/analyzer/jenkins_analyzer.ts
@@ -61,7 +61,8 @@ type JobReport = {
   url: ""; // Jenkins does not provide each stage url
   executorClass: ""; // JenkinsAnalyzer does not support
   executorType: ""; // JenkinsAnalyzer does not support
-  executorName: ""; // JenkinsAnalyzer doen not support
+  executorName: ""; // JenkinsAnalyzer does not support
+  queuedDurationSec: 0; // JenkinsAnalyzer does not support job queued duration yet
 };
 
 type StepReport = {
@@ -130,6 +131,7 @@ export class JenkinsAnalyzer implements Analyzer {
         executorClass: "",
         executorType: "",
         executorName: "",
+        queuedDurationSec: 0, // Not supported yet
       };
     });
 

--- a/src/pb_types/workflow.ts
+++ b/src/pb_types/workflow.ts
@@ -49,6 +49,7 @@ export interface PbJobReport {
   executorClass: string;
   executorType: string;
   executorName: string;
+  queuedDurationSec: number;
 }
 
 export interface PbStepReport {


### PR DESCRIPTION
fix: https://github.com/Kesin11/CIAnalyzer/issues/1302

Currently it only implemented GitHub Actions. Other services fill dummy value '0'.
BigQuery table schema will migrate automatically so it does not have breakings changes. (=minor update)