### PR TITLE
Add GcsExporter

### DIFF
--- a/__tests__/exporter/bigquery_exporter.test.ts
+++ b/__tests__/exporter/bigquery_exporter.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import { BigqueryExporter } from "../../src/exporter/bigquery_exporter";
-import type { BigqueryExporterConfig } from "../../src/config/config";
+import type { BigqueryExporterConfig } from "../../src/config/schema";
 import { CustomReportCollection } from "../../src/custom_report_collection";
 import { Logger } from "tslog";
 

--- a/__tests__/exporter/gcs_exporter.test.ts
+++ b/__tests__/exporter/gcs_exporter.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { GcsExporter } from "../../src/exporter/gcs_exporter";
+import type { GcsExporterConfig } from "../../src/config/schema";
+import { Logger } from "tslog";
+
+describe("GcsExporter", () => {
+  const baseConfig: GcsExporterConfig = {
+    project: "project",
+    bucket: "bucket",
+    pathTemplate: "gs://path/{reportType}/{YYYY}/{MM}/{DD}/{hh}/{mm}/{ss}.json",
+  };
+  const logger = new Logger({ type: "hidden" });
+
+  beforeEach(() => {
+    // Mock the current time for `now = dayjs()`
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2023-01-01T12:34:56Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers()
+  });
+
+  describe("new", () => {
+    it("should not throw when all required params are provided", () => {
+      expect(() => {
+        new GcsExporter(logger, baseConfig);
+      }).not.toThrow();
+    });
+
+    it("should throw when pathTemplate does not include {reportType}", () => {
+      const config = { ...baseConfig, pathTemplate: "gs://path/{YYYY}/{MM}/{DD}/{hh}/{mm}/{ss}.json" };
+      expect(() => {
+        new GcsExporter(logger, config);
+      }).toThrow();
+    });
+  });
+
+  describe("createFilePath", () => {
+    it("should create file path with all placeholders", () => {
+      const exporter = new GcsExporter(logger, baseConfig);
+      const filePath = exporter.createFilePath("workflow");
+      expect(filePath).toBe("path/workflow/2023/01/01/12/34/56.json");
+    });
+
+    it("should create file path without gs:// prefix", () => {
+      const config = { ...baseConfig, pathTemplate: "path/{reportType}/{YYYY}/{MM}/{DD}/{hh}/{mm}/{ss}.json" };
+      const exporter = new GcsExporter(logger, config);
+      const filePath = exporter.createFilePath("test");
+      expect(filePath).toBe("path/test/2023/01/01/12/34/56.json");
+    });
+
+    it("should create file path with YYYY, MM, DD placeholders", () => {
+      const config = { ...baseConfig, pathTemplate: "gs://path/{reportType}/{YYYY}/{MM}/{DD}.json" };
+      const exporter = new GcsExporter(logger, config);
+      const filePath = exporter.createFilePath("test");
+      expect(filePath).toBe("path/test/2023/01/01.json");
+    });
+  });
+});

--- a/__tests__/exporter/local_exporter.test.ts
+++ b/__tests__/exporter/local_exporter.test.ts
@@ -1,7 +1,7 @@
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import { LocalExporter } from "../../src/exporter/local_exporter";
 import path from "node:path";
-import type { LocalExporterConfig } from "../../src/config/config";
+import type { LocalExporterConfig } from "../../src/config/schema";
 import { Logger } from "tslog";
 
 const mockFsPromises = {

--- a/ci_analyzer.yaml
+++ b/ci_analyzer.yaml
@@ -31,6 +31,10 @@ github:
           table: $CUSTOM_REPORT_TABLE
           schema: ./$SCHEMA_DIR/$CUSTOM_REPORT_TABLE_SCHEMA.json # It accepts absolute path or relative path from this config yaml.
       maxBadRecords: 0 # (Optional) default: 0. If set > 0, skip bad record. This option should only be used for workaround.
+    gcs:
+      project: $GCP_PROJECT_ID
+      bucket: $BUCKET_NAME
+      pathTemplate: ci_analyzer/{type}/{YYYY}/{MM}/{DD}/{hh}/{mm}/{ss}.json
   lastRunStore:
     backend: gcs # Recommend using 'gcs' backend
     project: $GCP_PROJECT_ID

--- a/ci_analyzer.yaml
+++ b/ci_analyzer.yaml
@@ -34,8 +34,8 @@ github:
     gcs:
       project: $GCP_PROJECT_ID
       bucket: $BUCKET_NAME
-      # {reportType} placeholder is Required. Others are optional.
-      # {YYYY}, {MM}, {DD}, {hh} are also supported.
+      # {reportType} placeholder is Required.
+      # {YYYY}, {MM}, {DD} placeholders are optional.
       # If you want to use BigQuery external tables, the GCS path should be in a format supported by Hive partitions like this
       prefixTemplate: ci_analyzer/{reportType}/dt={YYYY}-{MM}-{DD}/
   lastRunStore:

--- a/ci_analyzer.yaml
+++ b/ci_analyzer.yaml
@@ -34,7 +34,8 @@ github:
     gcs:
       project: $GCP_PROJECT_ID
       bucket: $BUCKET_NAME
-      pathTemplate: ci_analyzer/{type}/{YYYY}/{MM}/{DD}/{hh}/{mm}/{ss}.json
+      # {reportType} placeholder is Required. Others are optional.
+      pathTemplate: gs://ci_analyzer/{reportType}/{YYYY}/{MM}/{DD}/{hh}/{mm}/{ss}.json
   lastRunStore:
     backend: gcs # Recommend using 'gcs' backend
     project: $GCP_PROJECT_ID

--- a/ci_analyzer.yaml
+++ b/ci_analyzer.yaml
@@ -35,8 +35,8 @@ github:
       project: $GCP_PROJECT_ID
       bucket: $BUCKET_NAME
       # {reportType} placeholder is Required. Others are optional.
-      # {YYYY}, {MM}, {DD}, {hh}, {mm}, {ss} are also supported.
-      # If you want query by BigQuery external table, gcs path should set as hive supported layout like this.
+      # {YYYY}, {MM}, {DD}, {hh} are also supported.
+      # If you want to use BigQuery external tables, the GCS path should be in a format supported by Hive partitions like this
       prefixTemplate: ci_analyzer/{reportType}/dt={YYYY}-{MM}-{DD}/
   lastRunStore:
     backend: gcs # Recommend using 'gcs' backend

--- a/ci_analyzer.yaml
+++ b/ci_analyzer.yaml
@@ -35,7 +35,9 @@ github:
       project: $GCP_PROJECT_ID
       bucket: $BUCKET_NAME
       # {reportType} placeholder is Required. Others are optional.
-      pathTemplate: gs://ci_analyzer/{reportType}/{YYYY}/{MM}/{DD}/{hh}/{mm}/{ss}.json
+      # {YYYY}, {MM}, {DD}, {hh}, {mm}, {ss} are also supported.
+      # If you want query by BigQuery external table, gcs path should set as hive supported layout like this.
+      prefixTemplate: ci_analyzer/{reportType}/dt={YYYY}-{MM}-{DD}/
   lastRunStore:
     backend: gcs # Recommend using 'gcs' backend
     project: $GCP_PROJECT_ID

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "biome:ci": "biome ci .",
     "lint:fix": "biome lint --apply-unsafe .",
     "fmt:fix": "biome format --write .",
-    "test": "vitest",
-    "test:ci": "vitest --run --coverage",
+    "test": "TZ=UTC vitest",
+    "test:ci": "TZ=UTC vitest --run --coverage",
     "proto": "earthly --strict --remote-cache=ghcr.io/kesin11/ci_analyzer_earthly:cache +proto",
     "docker": "earthly --strict --remote-cache=ghcr.io/kesin11/ci_analyzer_earthly:cache +docker",
     "schema": "earthly --strict --remote-cache=ghcr.io/kesin11/ci_analyzer_earthly:cache +schema"

--- a/schema.json
+++ b/schema.json
@@ -89,6 +89,26 @@
                     }
                   },
                   "additionalProperties": false
+                },
+                "gcs": {
+                  "type": "object",
+                  "properties": {
+                    "project": {
+                      "type": "string"
+                    },
+                    "bucket": {
+                      "type": "string"
+                    },
+                    "prefixTemplate": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "project",
+                    "bucket",
+                    "prefixTemplate"
+                  ],
+                  "additionalProperties": false
                 }
               },
               "additionalProperties": false

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -31,7 +31,7 @@ export type BigqueryExporterConfig = z.infer<typeof bigqueryExporterSchema>;
 const gcsExporterSchema = z.object({
   project: z.string(),
   bucket: z.string(),
-  pathTemplate: z.string(),
+  prefixTemplate: z.string(),
 });
 export type GcsExporterConfig = z.infer<typeof gcsExporterSchema>;
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -28,9 +28,17 @@ const bigqueryExporterSchema = z.object({
 });
 export type BigqueryExporterConfig = z.infer<typeof bigqueryExporterSchema>;
 
+const gcsExporterSchema = z.object({
+  project: z.string(),
+  bucket: z.string(),
+  pathTemplate: z.string(),
+});
+export type GcsExporterConfig = z.infer<typeof gcsExporterSchema>;
+
 const exporterSchema = z.object({
   local: localExporterSchema.optional(),
   bigquery: bigqueryExporterSchema.optional(),
+  gcs: gcsExporterSchema.optional(),
 });
 export type ExporterConfig = z.infer<typeof exporterSchema>;
 

--- a/src/exporter/exporter.ts
+++ b/src/exporter/exporter.ts
@@ -43,7 +43,10 @@ export class CompositExporter implements Exporter {
 
     this.exporters = exporters
       .map((exporter) => {
-        let _config: LocalExporterConfig | BigqueryExporterConfig | GcsExporterConfig;
+        let _config:
+          | LocalExporterConfig
+          | BigqueryExporterConfig
+          | GcsExporterConfig;
         switch (exporter) {
           case "local":
             _config = config[exporter] ?? {};
@@ -58,7 +61,11 @@ export class CompositExporter implements Exporter {
             return new BigqueryExporter(logger, _config, options.configDir);
           case "gcs":
             _config = config[exporter] ?? {};
-            return new GcsExporter(logger, _config as GcsExporterConfig);
+            return new GcsExporter(
+              logger,
+              service,
+              _config as GcsExporterConfig,
+            );
         }
       })
       .filter((exporter) => exporter !== undefined);

--- a/src/exporter/exporter.ts
+++ b/src/exporter/exporter.ts
@@ -4,11 +4,13 @@ import type {
   ExporterConfig,
   LocalExporterConfig,
   BigqueryExporterConfig,
+  GcsExporterConfig,
 } from "../config/schema.js";
 import { BigqueryExporter } from "./bigquery_exporter.js";
 import type { CustomReportCollection } from "../custom_report_collection.js";
 import type { ArgumentOptions } from "../arg_options.js";
 import type { Logger } from "tslog";
+import { GcsExporter } from "./gcs_exporter.js";
 
 export interface Exporter {
   exportWorkflowReports(reports: WorkflowReport[]): Promise<void>;
@@ -41,7 +43,7 @@ export class CompositExporter implements Exporter {
 
     this.exporters = exporters
       .map((exporter) => {
-        let _config: LocalExporterConfig | BigqueryExporterConfig;
+        let _config: LocalExporterConfig | BigqueryExporterConfig | GcsExporterConfig;
         switch (exporter) {
           case "local":
             _config = config[exporter] ?? {};
@@ -54,6 +56,9 @@ export class CompositExporter implements Exporter {
           case "bigquery":
             _config = config[exporter] ?? {};
             return new BigqueryExporter(logger, _config, options.configDir);
+          case "gcs":
+            _config = config[exporter] ?? {};
+            return new GcsExporter(logger, _config as GcsExporterConfig);
         }
       })
       .filter((exporter) => exporter !== undefined);

--- a/src/exporter/exporter.ts
+++ b/src/exporter/exporter.ts
@@ -28,7 +28,7 @@ export class CompositExporter implements Exporter {
     service: string,
     config?: ExporterConfig,
   ) {
-    if (options.debug || !config) {
+    if ((options.debug && options.onlyExporters === undefined) || !config) {
       this.exporters = [
         new LocalExporter(logger, service, options.configDir, {}),
       ];

--- a/src/exporter/gcs_exporter.ts
+++ b/src/exporter/gcs_exporter.ts
@@ -1,16 +1,16 @@
 import { Storage } from "@google-cloud/storage";
-import { Exporter } from "./exporter";
-import { WorkflowReport, TestReport } from "../analyzer/analyzer";
-import { GcsExporterConfig } from "../config/schema";
-import { CustomReportCollection } from "../custom_report_collection";
+import { Exporter } from "./exporter.js";
+import { WorkflowReport, TestReport } from "../analyzer/analyzer.js";
+import { GcsExporterConfig } from "../config/schema.js";
+import { CustomReportCollection } from "../custom_report_collection.js";
 import { Logger } from "tslog";
 import dayjs from "dayjs";
 
 export class GcsExporter implements Exporter {
-  private storage: Storage;
-  private bucketName: string;
-  private pathTemplate: string;
-  private logger: Logger<unknown>;
+  storage: Storage;
+  bucketName: string;
+  pathTemplate: string;
+  logger: Logger<unknown>;
 
   constructor(logger: Logger<unknown>, config: GcsExporterConfig) {
     if (!config.project || !config.bucket || !config.pathTemplate) {

--- a/src/exporter/gcs_exporter.ts
+++ b/src/exporter/gcs_exporter.ts
@@ -34,17 +34,7 @@ export class GcsExporter implements Exporter {
   }
 
   private async export(reports: unknown[], reportType: string) {
-    const now = dayjs();
-    const filePath = this.pathTemplate
-      .replace("gs://", "")
-      .replace("{reportType}", reportType)
-      .replace("{YYYY}", now.format("YYYY"))
-      .replace("{MM}", now.format("MM"))
-      .replace("{DD}", now.format("DD"))
-      .replace("{hh}", now.format("HH"))
-      .replace("{mm}", now.format("mm"))
-      .replace("{ss}", now.format("ss"));
-
+    const filePath = this.createFilePath(reportType);
     const bucket = this.storage.bucket(this.bucketName);
     const file = bucket.file(filePath);
     const reportJson = this.formatJsonLines(reports);
@@ -58,6 +48,20 @@ export class GcsExporter implements Exporter {
     });
 
     this.logger.info(`Successfully uploaded to gs://${this.bucketName}/${filePath}`);
+  }
+
+  createFilePath(reportType: string) {
+    const now = dayjs();
+    const filePath = this.pathTemplate
+      .replace("gs://", "")
+      .replace("{reportType}", reportType)
+      .replace("{YYYY}", now.format("YYYY"))
+      .replace("{MM}", now.format("MM"))
+      .replace("{DD}", now.format("DD"))
+      .replace("{hh}", now.format("HH"))
+      .replace("{mm}", now.format("mm"))
+      .replace("{ss}", now.format("ss"));
+    return filePath;
   }
 
   async exportWorkflowReports(reports: WorkflowReport[]) {

--- a/src/exporter/gcs_exporter.ts
+++ b/src/exporter/gcs_exporter.ts
@@ -1,0 +1,70 @@
+import { Storage } from "@google-cloud/storage";
+import { Exporter } from "./exporter";
+import { WorkflowReport, TestReport } from "../analyzer/analyzer";
+import { GcsExporterConfig } from "../config/schema";
+import { CustomReportCollection } from "../custom_report_collection";
+import { Logger } from "tslog";
+import dayjs from "dayjs";
+
+export class GcsExporter implements Exporter {
+  private storage: Storage;
+  private bucketName: string;
+  private pathTemplate: string;
+  private logger: Logger<unknown>;
+
+  constructor(logger: Logger<unknown>, config: GcsExporterConfig) {
+    if (!config.project || !config.bucket || !config.pathTemplate) {
+      throw new Error(
+        "Must need 'project', 'bucket', and 'pathTemplate' parameters in exporter.gcs config."
+      );
+    }
+    this.logger = logger.getSubLogger({ name: GcsExporter.name });
+    this.storage = new Storage({ projectId: config.project });
+    this.bucketName = config.bucket;
+    this.pathTemplate = config.pathTemplate;
+  }
+
+  private formatJsonLines(reports: unknown[]): string {
+    return reports.map((report) => JSON.stringify(report)).join("\n");
+  }
+
+  private async export(reports: unknown[], type: string) {
+    const now = dayjs();
+    const filePath = this.pathTemplate
+      .replace("{type}", type)
+      .replace("{YYYY}", now.format("YYYY"))
+      .replace("{MM}", now.format("MM"))
+      .replace("{DD}", now.format("DD"))
+      .replace("{hh}", now.format("HH"))
+      .replace("{mm}", now.format("mm"))
+      .replace("{ss}", now.format("ss"));
+
+    const bucket = this.storage.bucket(this.bucketName);
+    const file = bucket.file(filePath);
+    const reportJson = this.formatJsonLines(reports);
+
+    this.logger.info(
+      `Uploading ${type} reports to gs://${this.bucketName}/${filePath}`
+    );
+
+    await file.save(reportJson, {
+      contentType: "application/json",
+    });
+
+    this.logger.info(`Successfully uploaded to gs://${this.bucketName}/${filePath}`);
+  }
+
+  async exportWorkflowReports(reports: WorkflowReport[]) {
+    await this.export(reports, "workflow");
+  }
+
+  async exportTestReports(reports: TestReport[]) {
+    await this.export(reports, "test");
+  }
+
+  async exportCustomReports(customReportCollection: CustomReportCollection) {
+    for (const [name, reports] of customReportCollection.customReports) {
+      await this.export(reports, name);
+    }
+  }
+}


### PR DESCRIPTION
Add `exporter.gcs` config that allows CIAnalyzer export JSONL files to GCS.

BigQuery can also read JSONL formatted data stored in GCS as [external tables](https://cloud.google.com/bigquery/docs/external-data-cloud-storage), so it is useful to save data to GCS instead of exporting directly to a BigQuery table.

----
Initial [Copilot Workspace Session](https://copilot-workspace.githubnext.com/Kesin11/CIAnalyzer?shareId=cd1138d7-8fd9-4811-a19b-cb78c8722d5f)