### PR TITLE
Pin action versions and add permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
       - "**.md"
       - "renovate.json"
       - "Jenkinsfile"
+permissions:
+  contents: read
 
 jobs:
   check_generated_files:
@@ -43,6 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: "node:lts"
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       # Setup
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: earthly/actions-setup@v1.0.13
+      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
         with:
           version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -75,14 +75,14 @@ jobs:
           path: |
             junit/*.xml
             custom_report.json
-      - uses: k1LoW/octocov-action@v1
+      - uses: k1LoW/octocov-action@1ad702b3118b6a055c00b01db68ca0d9f6641dbc # v1.4.0
         name: Upload coverage
 
   docker-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: earthly/actions-setup@v1.0.13
+      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
         with:
           version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: earthly/actions-setup@v1.0.13
+      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
         with:
           version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
         id: docker_meta
         with:
           images: ghcr.io/kesin11/ci_analyzer
@@ -28,7 +28,7 @@ jobs:
             type=semver,pattern=v{{major}}.{{minor}}
       - name: Login to ghcr
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   docker-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       tag_name: ${{ steps.release-drafter.outputs.tag_name }}
     steps:
       # Get next version
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6.0.0
         id: release-drafter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -44,7 +44,7 @@ jobs:
           npm version $VERSION
           git push origin master
           git push origin "v${VERSION}"
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6.0.0
         with:
           publish: true
           tag: v${{ env.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,12 @@ on:
     branches:
       - master
   workflow_dispatch:
+
 jobs:
   draft_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       tag_name: ${{ steps.release-drafter.outputs.tag_name }}
     steps:
@@ -21,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
     needs: draft_release
+    permissions:
+      contents: write
     steps:
       # Create version string from tag (v1.0.0 -> 1.0.0)
       - name: Create version string


### PR DESCRIPTION
Pin specific commit hashes for third-party actions and explicitly define permissions for workflows to enhance security and control.