### PR TITLE
Revert @google-cloud/common v6 to v5.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
-        "@google-cloud/common": "^6.0.0",
+        "@google-cloud/common": "5.0.2",
         "@types/adm-zip": "0.5.7",
         "@types/js-yaml": "4.0.9",
         "@types/lodash-es": "4.17.12",
@@ -741,7 +741,20 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@google-cloud/bigquery/node_modules/@google-cloud/common": {
+    "node_modules/@google-cloud/bigquery/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@google-cloud/common": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-5.0.2.tgz",
       "integrity": "sha512-V7bmBKYQyu0eVG2BFejuUjlBt+zrya6vtsKdY+JxMM/dNntPF41vZ9+LhOshEUH01zOHEqBSvI7Dad7ZS6aUeA==",
@@ -759,176 +772,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@google-cloud/bigquery/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@google-cloud/common": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-6.0.0.tgz",
-      "integrity": "sha512-IXh04DlkLMxWgYLIUYuHHKXKOUwPDzDgke1ykkkJPe48cGIS9kkL2U/o0pm4ankHLlvzLF/ma1eO86n/bkumIA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@google-cloud/projectify": "^4.0.0",
-        "@google-cloud/promisify": "^4.0.0",
-        "arrify": "^2.0.0",
-        "duplexify": "^4.1.3",
-        "extend": "^3.0.2",
-        "google-auth-library": "^10.0.0-rc.1",
-        "html-entities": "^2.5.2",
-        "retry-request": "^8.0.0",
-        "teeny-request": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@google-cloud/common/node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@google-cloud/common/node_modules/gaxios": {
-      "version": "7.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.0.0-rc.4.tgz",
-      "integrity": "sha512-fwQMwbs3o8Odl/nc/rkQJwyHeOXdderOwmybUl0gkyTdZXMK1oSTWj4Em7gSogVJsRWDeHPXLY06+e8Rkr01iw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@google-cloud/common/node_modules/gaxios/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@google-cloud/common/node_modules/gcp-metadata": {
-      "version": "7.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.0-rc.1.tgz",
-      "integrity": "sha512-E6c+AdIaK1LNA839OyotiTca+B2IG1nDlMjnlcck8JjXn3fVgx57Ib9i6iL1/iqN7bA3EUQdcRRu+HqOCOABIg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "gaxios": "^7.0.0-rc.1",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@google-cloud/common/node_modules/google-auth-library": {
-      "version": "10.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.0.0-rc.1.tgz",
-      "integrity": "sha512-Ri8Yk7bMhaPcqzwyW5XHS4scc5KL+AdyUVxA5YGw9BUxYcL2P/tdEfj13O9KpV03k5sUqlaTL+HPxb/deGVjxw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.0.0-rc.4",
-        "gcp-metadata": "^7.0.0-rc.1",
-        "gtoken": "^8.0.0-rc.1",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@google-cloud/common/node_modules/gtoken": {
-      "version": "8.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0-rc.1.tgz",
-      "integrity": "sha512-UjE/egX6ixArdcCKOkheuFQ4XN4/0gX92nd2JPVEYuRU2sWHAWuOVGnowm1fQUdQtaxqn1n8H0hOb2LCaUhJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "gaxios": "^7.0.0-rc.1",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@google-cloud/common/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/@google-cloud/common/node_modules/retry-request": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.0.tgz",
-      "integrity": "sha512-dJkZNmyV9C8WKUmbdj1xcvVlXBSvsUQCkg89TCK8rD72RdSn9A2jlXlS2VuYSTHoPJjJEfUHhjNYrlvuksF9cg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/request": "^2.48.12",
-        "extend": "^3.0.2",
-        "teeny-request": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@google-cloud/common/node_modules/teeny-request": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.0.0.tgz",
-      "integrity": "sha512-GSenHGKrnSVnlCzgrhwUVujtwiZUEBA0H4rY783rkrPlBTGaDYibjXj6VbGyP8BpKIJulvMYhKmLuoDCvEWi6w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^3.3.2",
-        "stream-events": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@google-cloud/paginator": {
@@ -2137,16 +1980,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/dayjs": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
@@ -2375,30 +2208,6 @@
         "fxparser": "src/cli/cli.js"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/follow-redirects": {
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
@@ -2446,19 +2255,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/fsevents": {
@@ -2582,16 +2378,6 @@
         "gtoken": "^7.0.0",
         "jws": "^4.0.0"
       },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/google-logging-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.0.tgz",
-      "integrity": "sha512-ARaE/CVO0gjI7UI/erOgA30pZeDTJvWQpVisyZFHYMVHPhz+kQsLGjkvMAJ0Ff9u+HPwWadow9/2fqSq/Kxnlg==",
-      "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }
@@ -2994,26 +2780,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
@@ -4275,16 +4041,6 @@
         "jsdom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
-    "@google-cloud/common": "^6.0.0",
+    "@google-cloud/common": "5.0.2",
     "@types/adm-zip": "0.5.7",
     "@types/js-yaml": "4.0.9",
     "@types/lodash-es": "4.17.12",


### PR DESCRIPTION
This pull request addresses a potential issue introduced by #1430, which may have caused the BigQuery exporter to break. It appears that the version of gaxios has changed, leading to this problem.

Error log in my testing workflow that uses CIAnalyzer master branch. It seems gaxios related this error.

```
node:internal/process/promises:394
    triggerUncaughtException(err, true /* fromPromise */);
    ^
_GaxiosError: Expected signal to be an instanceof AbortSignal
    at Gaxios._request (file:///ci_analyzer/dist/index.mjs:15543:65)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async IdentityPoolClient.requestAsync (file:///ci_analyzer/dist/index.mjs:21392:22)
    at async Upload.makeRequestStream (file:///ci_analyzer/dist/index.mjs:86401:17)
    at async Upload.startUploading (file:///ci_analyzer/dist/index.mjs:86240:20) {
  config: {
    method: 'PUT',
    url: 'https://storage.googleapis.com/upload/storage/v1/b/kesin11-ci-analyzer/o?name=ci_analyzer%2Flast_run%2Fgithub.json&uploadType=resumable&upload_id=AKDAyIvnOLzoGcnvrGxVgJudPzaAUHYk6gsaxSTSAK6kf1Z4OLxDaIvL3lTgwJd64wKDDyBPGn1sG0SV6tgSJq_Dvd8A_BTn8cWIsyxp0m7bv58',
    headers: {
      'User-Agent': 'gcloud-node-storage/7.15.2 google-api-nodejs-client/9.6.3',
      'x-goog-api-client': 'gl-node/22.14.0 gccl/7.15.2-ESM gccl-invocation-id/77968fd9-c6f9-4b3f-b2f7-0716eb2ac8d0',
      'Content-Range': 'bytes 0-*/*',
      Authorization: '***'
    },
    body: Readable {
      _events: {
        close: undefined,
        error: [Function (anonymous)],
        data: undefined,
        end: undefined,
        readable: undefined
      },
      _readableState: ReadableState {
        highWaterMark: 65536,
        buffer: [],
        bufferIndex: 0,
        length: 0,
        pipes: [],
        awaitDrainWriters: null,
        [Symbol(kState)]: 1052940
      },
      _read: [AsyncFunction: read],
      _maxListeners: undefined,
      _eventsCount: 1,
      [Symbol(shapeMode)]: true,
      [Symbol(kCapture)]: false
    },
    signal: AbortSignal2 [AbortSignal] {},
    validateStatus: [Function (anonymous)],
    paramsSerializer: [Function: paramsSerializer],
    responseType: 'unknown',
    errorRedactor: [Function: defaultErrorRedactor]
  },
  response: undefined,
  error: TypeError: Expected signal to be an instanceof AbortSignal
      at new _Request (file:///ci_analyzer/dist/index.mjs:1[35](https://github.com/kesin11-private/cianalyzer_config/actions/runs/13873959977/job/38823955667#step:5:36)27:17)
      at file:///ci_analyzer/dist/index.mjs:13654:26
      at new Promise (<anonymous>)
      at fetch3 (file:///ci_analyzer/dist/index.mjs:1[36](https://github.com/kesin11-private/cianalyzer_config/actions/runs/13873959977/job/38823955667#step:5:37)53:14)
      at Gaxios._defaultAdapter (file:///ci_analyzer/dist/index.mjs:15511:27)
      at Gaxios._request (file:///ci_analyzer/dist/index.mjs:15526:45)
      at Gaxios.request (file:///ci_analyzer/dist/index.mjs:15507:21)
      at _DefaultTransporter.request (file:///ci_analyzer/dist/index.mjs:18276:30)
      at IdentityPoolClient.requestAsync (file:///ci_analyzer/dist/index.mjs:21[39](https://github.com/kesin11-private/cianalyzer_config/actions/runs/13873959977/job/38823955667#step:5:40)2:45)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5),
  [Symbol(gaxios-gaxios-error)]: '6.3.0'
}
```

`npm ls gaxios` with @google-cloud/common@6.0.0

```
ci_analyzer@6.2.1 /home/kesin/github/kesin11/CIAnalyzer
├─┬ @google-cloud/common@6.0.0
│ └─┬ google-auth-library@10.0.0-rc.1
│   ├── gaxios@7.0.0-rc.4
│   ├─┬ gcp-metadata@7.0.0-rc.1
│   │ └── gaxios@7.0.0-rc.4 deduped
│   └─┬ gtoken@8.0.0-rc.1
│     └── gaxios@7.0.0-rc.4 deduped
└─┬ @google-cloud/storage@7.15.2
  ├── gaxios@6.3.0
  └─┬ google-auth-library@9.6.3
    ├── gaxios@6.3.0 deduped
    ├─┬ gcp-metadata@6.1.0
    │ └── gaxios@6.3.0 deduped
    └─┬ gtoken@7.0.1
      └── gaxios@6.3.0 deduped
```

`npm ls gaxios` with @google-cloud/common@5.0.2

```
ci_analyzer@6.2.1 /home/kesin/github/kesin11/CIAnalyzer
├─┬ @google-cloud/common@5.0.2
│ └─┬ google-auth-library@9.6.3
│   ├── gaxios@6.3.0 deduped
│   ├─┬ gcp-metadata@6.1.0
│   │ └── gaxios@6.3.0 deduped
│   └─┬ gtoken@7.0.1
│     └── gaxios@6.3.0 deduped
└─┬ @google-cloud/storage@7.15.2
  └── gaxios@6.3.0
```
