### PR TITLE
Use newer earthly/actions-setup that supports new GHA caches v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
+      # Since the version of earthly/actions-setup that supports the new GHA caches (v2) has not been released yet from v1.0.13,
+      # we use a commit hash that already includes the support.
+      # https://github.com/earthly/actions-setup/commit/b81a8e082d9fae6174210cfc6e54bd2feb124d94
+      - uses: earthly/actions-setup@b81a8e082d9fae6174210cfc6e54bd2feb124d94
         with:
           version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -111,7 +114,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
+      # Since the version of earthly/actions-setup that supports the new GHA caches (v2) has not been released yet from v1.0.13,
+      # we use a commit hash that already includes the support.
+      # https://github.com/earthly/actions-setup/commit/b81a8e082d9fae6174210cfc6e54bd2feb124d94
+      - uses: earthly/actions-setup@b81a8e082d9fae6174210cfc6e54bd2feb124d94
         with:
           version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,10 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
+      # Since the version of earthly/actions-setup that supports the new GHA caches (v2) has not been released yet from v1.0.13,
+      # we use a commit hash that already includes the support.
+      # https://github.com/earthly/actions-setup/commit/b81a8e082d9fae6174210cfc6e54bd2feb124d94
+      - uses: earthly/actions-setup@b81a8e082d9fae6174210cfc6e54bd2feb124d94
         with:
           version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
earthly/actions-setup support new GHA caches (v2) by https://github.com/earthly/actions-setup/pull/113
However, newer version has not been released yet. So we use fixed commit by pinned hash.