### PR TITLE
Remove yargs CLI dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "tsx": "4.21.0",
         "undici": "8.1.0",
         "utility-types": "3.11.0",
-        "yargs": "18.0.0",
         "zod": "4.3.6"
       },
       "bin": {
@@ -37,7 +36,6 @@
         "@types/js-yaml": "4.0.9",
         "@types/lodash-es": "4.17.12",
         "@types/node": "24.12.2",
-        "@types/yargs": "17.0.35",
         "@vitest/coverage-v8": "^4.1.5",
         "ts-proto": "2.11.6",
         "ts-protoc-gen": "0.15.0",
@@ -1094,22 +1092,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/yargs": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
-      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
-      "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
-      "dev": true
-    },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
@@ -1421,70 +1403,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/cliui": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
-      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
-      "license": "MIT"
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1646,14 +1564,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/estree-walker": {
@@ -1829,26 +1739,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3775,85 +3665,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/emoji-regex": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
-      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -3879,95 +3690,11 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "node_modules/yargs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^9.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "string-width": "^7.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^22.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-      "license": "ISC",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
-      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
-      "license": "MIT"
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "tsx": "4.21.0",
     "undici": "8.1.0",
     "utility-types": "3.11.0",
-    "yargs": "18.0.0",
     "zod": "4.3.6"
   },
   "devDependencies": {
@@ -62,7 +61,6 @@
     "@types/js-yaml": "4.0.9",
     "@types/lodash-es": "4.17.12",
     "@types/node": "24.12.2",
-    "@types/yargs": "17.0.35",
     "@vitest/coverage-v8": "^4.1.5",
     "ts-proto": "2.11.6",
     "ts-protoc-gen": "0.15.0",

--- a/src/arg_options.ts
+++ b/src/arg_options.ts
@@ -1,7 +1,258 @@
 import path from "node:path";
+import { parseArgs } from "node:util";
+import type { ParseArgsOptionsConfig } from "node:util";
 
 type Argv = {
   [x: string]: unknown;
+};
+
+type CliToken =
+  | {
+      kind: "option";
+      index: number;
+      name: string;
+      rawName: string;
+      value: string | undefined;
+      inlineValue: boolean | undefined;
+    }
+  | { kind: "positional"; index: number; value: string }
+  | { kind: "option-terminator"; index: number };
+type OptionToken = Extract<CliToken, { kind: "option" }>;
+type PositionalToken = Extract<CliToken, { kind: "positional" }>;
+
+const defaultConfigPath = "./ci_analyzer.yaml";
+
+const optionDescriptions = [
+  {
+    names: "-c, --config",
+    value: "<path>",
+    description: "Path to config yaml",
+    defaultValue: defaultConfigPath,
+  },
+  {
+    names: "-v, --verbose",
+    description: "Enable debug log level. Repeatable, e.g. -vv",
+  },
+  {
+    names: "--debug",
+    description: "Enable debug mode",
+    defaultValue: "false",
+  },
+  {
+    names: "--only-services",
+    value: "<services...>",
+    description:
+      "Exec only selected services. ex: --only-services circleci github",
+  },
+  {
+    names: "--only-exporters",
+    value: "<exporters...>",
+    description:
+      "Export data using only selected exporters. ex: --only-exporters local",
+  },
+  {
+    names: "--keepalive",
+    description: "Enable http/https keepalive",
+    defaultValue: "true",
+  },
+  {
+    names: "--max-concurrent-requests",
+    value: "<number>",
+    description:
+      "Limit http request concurrency per service. When set 0, disable concurrency limit",
+    defaultValue: "10",
+  },
+  {
+    names: "--force-save-last-run",
+    description:
+      "Save last run state even when errors occur during data collection",
+    defaultValue: "false",
+  },
+  {
+    names: "--help",
+    description: "Show help",
+  },
+];
+
+type ParsedArgs = {
+  values: Argv;
+  positionals: string[];
+  tokens: CliToken[];
+};
+
+const optionConfig: ParseArgsOptionsConfig = {
+  config: {
+    type: "string",
+    short: "c",
+    default: defaultConfigPath,
+  },
+  verbose: {
+    type: "boolean",
+    short: "v",
+    multiple: true,
+    default: [],
+  },
+  debug: {
+    type: "boolean",
+    default: false,
+  },
+  "only-services": {
+    type: "string",
+    multiple: true,
+  },
+  "only-exporters": {
+    type: "string",
+    multiple: true,
+  },
+  keepalive: {
+    type: "boolean",
+    default: true,
+  },
+  "max-concurrent-requests": {
+    type: "string",
+    default: "10",
+  },
+  "force-save-last-run": {
+    type: "boolean",
+    default: false,
+  },
+  help: {
+    type: "boolean",
+    default: false,
+  },
+} as const;
+
+export const createHelpMessage = (): string => {
+  const optionRows = optionDescriptions.map((option) => {
+    const optionLabel = [option.names, option.value].filter(Boolean).join(" ");
+    const description = option.defaultValue
+      ? `${option.description} [default: ${option.defaultValue}]`
+      : option.description;
+
+    return { optionLabel, description };
+  });
+  const optionColumnWidth = Math.max(
+    ...optionRows.map((row) => row.optionLabel.length),
+  );
+  const optionLines = optionRows
+    .map(
+      (row) =>
+        `  ${row.optionLabel.padEnd(optionColumnWidth)}  ${row.description}`,
+    )
+    .join("\n");
+
+  return [
+    "ci_analyzer [workflow]",
+    "",
+    "Collect workflow data from CI services",
+    "",
+    "Options:",
+    optionLines,
+    "",
+  ].join("\n");
+};
+
+const normalizeArrayOption = (
+  parsedArgs: ParsedArgs,
+  optionName: string,
+): Set<number> => {
+  const optionTokens = parsedArgs.tokens.filter(
+    (token): token is OptionToken =>
+      token.kind === "option" && token.name === optionName,
+  );
+  if (optionTokens.length === 0) {
+    parsedArgs.values[optionName] = undefined;
+    return new Set();
+  }
+
+  const values: string[] = [];
+  const consumedPositionalIndexes = new Set<number>();
+  for (const token of optionTokens) {
+    if (typeof token.value === "string") {
+      values.push(token.value);
+    }
+
+    const index = parsedArgs.tokens.indexOf(token);
+
+    for (const nextToken of parsedArgs.tokens.slice(index + 1)) {
+      if (nextToken.kind !== "positional") {
+        break;
+      }
+
+      values.push(nextToken.value);
+      consumedPositionalIndexes.add(nextToken.index);
+    }
+  }
+
+  parsedArgs.values[optionName] = values;
+  return consumedPositionalIndexes;
+};
+
+const normalizeVerboseOption = (argv: Argv) => {
+  const verboseValues = argv.verbose;
+  argv.v = Array.isArray(verboseValues) ? verboseValues.length : 0;
+};
+
+const normalizeConfigOption = (argv: Argv) => {
+  argv.c = argv.config;
+};
+
+const normalizeMaxConcurrentRequestsOption = (argv: Argv) => {
+  const value = argv["max-concurrent-requests"];
+  if (typeof value !== "string") {
+    argv["max-concurrent-requests"] = 10;
+    return;
+  }
+
+  const numericValue = Number(value);
+  if (!Number.isInteger(numericValue) || numericValue < 0) {
+    throw new TypeError(
+      `Invalid value for --max-concurrent-requests: ${value}. Expected a non-negative integer.`,
+    );
+  }
+
+  argv["max-concurrent-requests"] = numericValue;
+};
+
+const validatePositionals = (positionals: string[]) => {
+  const unsupportedPositionals = positionals.filter(
+    (positional) => positional !== "workflow",
+  );
+  if (unsupportedPositionals.length > 0) {
+    throw new TypeError(
+      `Unknown argument: ${unsupportedPositionals.join(" ")}`,
+    );
+  }
+};
+
+export const parseCliArgs = (args = process.argv.slice(2)): Argv => {
+  const parsedArgs = parseArgs({
+    args,
+    options: optionConfig,
+    strict: true,
+    allowPositionals: true,
+    allowNegative: true,
+    tokens: true,
+  }) as ParsedArgs;
+
+  const arrayOptionPositionalIndexes = new Set([
+    ...normalizeArrayOption(parsedArgs, "only-services"),
+    ...normalizeArrayOption(parsedArgs, "only-exporters"),
+  ]);
+  const commandPositionals = parsedArgs.tokens
+    .filter(
+      (token): token is PositionalToken =>
+        token.kind === "positional" &&
+        !arrayOptionPositionalIndexes.has(token.index),
+    )
+    .map((token) => token.value);
+  validatePositionals(commandPositionals);
+
+  normalizeVerboseOption(parsedArgs.values);
+  normalizeConfigOption(parsedArgs.values);
+  normalizeMaxConcurrentRequestsOption(parsedArgs.values);
+
+  return parsedArgs.values;
 };
 
 export class ArgumentOptions {

--- a/src/arg_options.ts
+++ b/src/arg_options.ts
@@ -72,6 +72,10 @@ const optionDescriptions = [
     names: "--help",
     description: "Show help",
   },
+  {
+    names: "--version",
+    description: "Show version number",
+  },
 ];
 
 type ParsedArgs = {
@@ -117,6 +121,10 @@ const optionConfig: ParseArgsOptionsConfig = {
     default: false,
   },
   help: {
+    type: "boolean",
+    default: false,
+  },
+  version: {
     type: "boolean",
     default: false,
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
 import { Logger } from "tslog";
 import {
   ArgumentOptions,
@@ -11,10 +12,33 @@ import { validateConfig } from "./config/config.js";
 
 const baseLoggerForStyles = new Logger();
 
+const readPackageVersion = (): string => {
+  const packageJson = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+  ) as { version: string };
+
+  return packageJson.version;
+};
+
 const main = async () => {
-  const argv = parseCliArgs();
+  let argv: ReturnType<typeof parseCliArgs>;
+  try {
+    argv = parseCliArgs();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Error: ${message}`);
+    console.error(createHelpMessage());
+    process.exitCode = 1;
+    return;
+  }
+
   if (argv.help) {
     console.log(createHelpMessage());
+    return;
+  }
+
+  if (argv.version) {
+    console.log(readPackageVersion());
     return;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,64 +1,23 @@
 #!/usr/bin/env node
 import { Logger } from "tslog";
-import yargs from "yargs";
-import { hideBin } from "yargs/helpers";
-import { ArgumentOptions } from "./arg_options.js";
+import {
+  ArgumentOptions,
+  createHelpMessage,
+  parseCliArgs,
+} from "./arg_options.js";
 import { loadConfig } from "./config/config.js";
 import { CompositRunner } from "./runner/runner.js";
 import { validateConfig } from "./config/config.js";
 
-const defaultConfigPath = "./ci_analyzer.yaml";
 const baseLoggerForStyles = new Logger();
 
 const main = async () => {
-  const argv = yargs(hideBin(process.argv))
-    .command(
-      ["$0", "workflow"],
-      "Collect workflow data from CI services",
-      (_yargs) => {},
-      () => {},
-    )
-    .options({
-      c: {
-        type: "string",
-        alias: "config",
-        default: defaultConfigPath,
-        describe: "Path to config yaml",
-      },
-      v: { type: "count", alias: "verbose" },
-      debug: { type: "boolean", default: false, describe: "Enable debug mode" },
-      "only-services": {
-        type: "string",
-        array: true,
-        describe:
-          "Exec only selected services. ex: --only-services circleci github",
-      },
-      "only-exporters": {
-        type: "string",
-        array: true,
-        describe:
-          "Export data using only selected exporters. ex: --only-exporters local",
-      },
-      keepalive: {
-        type: "boolean",
-        default: true,
-        describe: "Enable http/https keepalive",
-      },
-      "max-concurrent-requests": {
-        type: "number",
-        default: 10,
-        describe:
-          "Limit http request concurrency per service. When set 0, disable concurrency limit",
-      },
-      "force-save-last-run": {
-        type: "boolean",
-        default: false,
-        describe:
-          "Save last run state even when errors occur during data collection",
-      },
-    })
-    .strict()
-    .parseSync();
+  const argv = parseCliArgs();
+  if (argv.help) {
+    console.log(createHelpMessage());
+    return;
+  }
+
   const argOptions = new ArgumentOptions(argv);
   const logger = new Logger({
     minLevel: argOptions.logLevel,

--- a/tests/arg_options.test.ts
+++ b/tests/arg_options.test.ts
@@ -66,6 +66,12 @@ describe("parseCliArgs", () => {
     expect(options.maxConcurrentRequests).toBeUndefined();
   });
 
+  it("parses version option", () => {
+    const argv = parseCliArgs(["--version"]);
+
+    expect(argv.version).toBe(true);
+  });
+
   it("throws for unknown positional arguments", () => {
     expect(() => parseCliArgs(["unknown"])).toThrow("Unknown argument");
   });
@@ -83,5 +89,6 @@ describe("createHelpMessage", () => {
     expect(help).toContain("--only-exporters <exporters...>");
     expect(help).toContain("--force-save-last-run");
     expect(help).toContain("--help");
+    expect(help).toContain("--version");
   });
 });

--- a/tests/arg_options.test.ts
+++ b/tests/arg_options.test.ts
@@ -1,0 +1,87 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  ArgumentOptions,
+  createHelpMessage,
+  parseCliArgs,
+} from "../src/arg_options.ts";
+
+describe("parseCliArgs", () => {
+  it("uses yargs-compatible defaults", () => {
+    const argv = parseCliArgs([]);
+    const options = new ArgumentOptions(argv);
+
+    expect(options.configPath).toBe(path.resolve("./ci_analyzer.yaml"));
+    expect(options.debug).toBe(false);
+    expect(options.logLevel).toBe(3);
+    expect(options.onlyServices).toBeUndefined();
+    expect(options.onlyExporters).toBeUndefined();
+    expect(options.keepAlive).toBe(true);
+    expect(options.maxConcurrentRequests).toBe(10);
+    expect(options.forceSaveLastRun).toBe(false);
+  });
+
+  it("parses aliases, booleans, numeric options, and repeated verbose flags", () => {
+    const argv = parseCliArgs([
+      "-c",
+      "config.yaml",
+      "-vv",
+      "--debug",
+      "--no-keepalive",
+      "--max-concurrent-requests",
+      "3",
+      "--force-save-last-run",
+    ]);
+    const options = new ArgumentOptions(argv);
+
+    expect(options.configPath).toBe(path.resolve("config.yaml"));
+    expect(options.debug).toBe(true);
+    expect(options.logLevel).toBe(2);
+    expect(options.keepAlive).toBe(false);
+    expect(options.maxConcurrentRequests).toBe(3);
+    expect(options.forceSaveLastRun).toBe(true);
+  });
+
+  it("parses yargs-style array options with space-separated values", () => {
+    const argv = parseCliArgs([
+      "workflow",
+      "--only-services",
+      "circleci",
+      "github",
+      "--only-services=jenkins",
+      "--only-exporters",
+      "local",
+      "bigquery",
+    ]);
+    const options = new ArgumentOptions(argv);
+
+    expect(options.onlyServices).toEqual(["circleci", "github", "jenkins"]);
+    expect(options.onlyExporters).toEqual(["local", "bigquery"]);
+  });
+
+  it("disables the concurrency limit when max-concurrent-requests is 0", () => {
+    const argv = parseCliArgs(["--max-concurrent-requests", "0"]);
+    const options = new ArgumentOptions(argv);
+
+    expect(options.maxConcurrentRequests).toBeUndefined();
+  });
+
+  it("throws for unknown positional arguments", () => {
+    expect(() => parseCliArgs(["unknown"])).toThrow("Unknown argument");
+  });
+});
+
+describe("createHelpMessage", () => {
+  it("includes command description and all public options", () => {
+    const help = createHelpMessage();
+
+    expect(help).toContain("ci_analyzer [workflow]");
+    expect(help).toContain("Collect workflow data from CI services");
+    expect(help).toContain("-c, --config <path>");
+    expect(help).toContain("-v, --verbose");
+    expect(help).toContain("--only-services <services...>");
+    expect(help).toContain("--only-exporters <exporters...>");
+    expect(help).toContain("--force-save-last-run");
+    expect(help).toContain("--help");
+  });
+});


### PR DESCRIPTION
## Summary
- Replace yargs-based CLI parsing with Node.js `util.parseArgs`
- Add a small built-in help renderer to preserve `--help` and `workflow --help` behavior
- Preserve existing option semantics for aliases, verbose counts, negative booleans, array-style values, and `--max-concurrent-requests 0`
- Remove `yargs` and `@types/yargs` from dependencies

## Verification
- `npm run fmt:fix`
- `npm run lint:fix`
- `npm run check`
- `npm test`
- `node ./bin/ci_analyzer.js --help`
- Manual parser check with `workflow -c config.yaml -vv --debug --only-services circleci github --only-exporters local --max-concurrent-requests 0 --force-save-last-run --no-keepalive`