### PR TITLE
Skip missing CircleCI job details

### DIFF
--- a/src/client/circleci_client_v2.ts
+++ b/src/client/circleci_client_v2.ts
@@ -455,9 +455,8 @@ export class CircleciClientV2 {
     const res = await this.#http.get(
       `v2/project/${projectSlug}/job/${jobNumber}`,
       {
-        validateStatus: (status) => {
-          return (status >= 200 && status < 300) || status === 404;
-        },
+        validateStatus: (status) =>
+          (status >= 200 && status < 300) || status === 404,
       },
     );
     if (res.status === 404) {

--- a/src/client/circleci_client_v2.ts
+++ b/src/client/circleci_client_v2.ts
@@ -1,12 +1,12 @@
 import path from "node:path";
 import { minimatch } from "minimatch";
-import { minBy } from "lodash-es";
 import type { Artifact, CustomReportArtifact } from "./artifact.js";
-import { createHttpClient, type HttpClient } from "./http_client.js";
+import { createHttpClient, HttpError, type HttpClient } from "./http_client.js";
 import type { CustomReportConfig } from "../config/schema.js";
 import type { ArgumentOptions } from "../arg_options.js";
 import type { Logger } from "tslog";
 import { failure, type Result, success } from "../result.js";
+import { minBy } from "lodash-es";
 import type { Overwrite } from "utility-types";
 
 export type CircleciStatus =
@@ -170,6 +170,28 @@ type GetJobDetailsResponse = {
   stopped_at?: string; // "2021-09-04T19:59:30.346Z"
 };
 
+type WorkflowJobWithDetail = {
+  workflowJob: FilteredWorkflowJob;
+  detail: GetJobDetailsResponse;
+};
+
+function isFetchableWorkflowJob(
+  jobResponse: ListWorkflowJobsResponse["items"][0],
+): jobResponse is FilteredWorkflowJob {
+  return (
+    jobResponse.status !== "blocked" &&
+    jobResponse.job_number !== undefined &&
+    jobResponse.type !== "approval"
+  );
+}
+
+function hasJobDetail(job: {
+  workflowJob: FilteredWorkflowJob;
+  detail: GetJobDetailsResponse | undefined;
+}): job is WorkflowJobWithDetail {
+  return job.detail !== undefined;
+}
+
 export type Workflow = ListWorkflowsByPipelineIdResponse["items"][0] & {
   jobs: Job[];
 };
@@ -230,6 +252,7 @@ export class CircleciClientV2 {
   #http: HttpClient;
   #baseUrl: string;
   #options: ArgumentOptions;
+  #logger: Logger<unknown>;
   constructor(
     token: string,
     logger: Logger<unknown>,
@@ -244,6 +267,7 @@ export class CircleciClientV2 {
     const httpLogger = logger.getSubLogger({ name: CircleciClientV2.name });
     this.#baseUrl = baseUrl ?? "https://circleci.com/api";
     this.#options = options;
+    this.#logger = httpLogger;
     this.#http = createHttpClient(httpLogger, options, {
       baseURL: this.#baseUrl,
       auth: {
@@ -368,43 +392,41 @@ export class CircleciClientV2 {
     const workflows: Workflow[] = [];
     for (const workflow of pipeline.workflows) {
       const jobResponses = await this.fetchWorkflowJobs(workflow.id);
-      // Filter jobs that this.fetchJob will be failed
-      const filterdWorkflowJobs = jobResponses.filter((jobResponse) => {
-        return (
-          jobResponse.status !== "blocked" &&
-          jobResponse.job_number !== undefined &&
-          jobResponse.type !== "approval"
-        );
-      }) as FilteredWorkflowJob[];
+      const filteredWorkflowJobs = jobResponses.filter(isFetchableWorkflowJob);
 
       // Fetch jobDetail and steps in parallel and then Combine to job
       const jobDetails = await Promise.all(
-        filterdWorkflowJobs.map((workflowJob) => {
+        filteredWorkflowJobs.map((workflowJob) => {
           return this.fetchJob(
             workflowJob.job_number,
             workflowJob.project_slug,
           );
         }),
       );
+      const fetchableWorkflowJobs = filteredWorkflowJobs
+        .map((workflowJob, index) => {
+          return { workflowJob, detail: jobDetails[index] };
+        })
+        .filter(hasJobDetail);
       const jobSteps = await Promise.all(
-        filterdWorkflowJobs.map((workflowJob) => {
+        fetchableWorkflowJobs.map(({ workflowJob }) => {
           return this.fetchJobSteps(
             workflowJob.job_number,
             workflowJob.project_slug,
           );
         }),
       );
-      const jobs: Job[] = filterdWorkflowJobs.map((workflowJobs) => {
-        return {
-          ...workflowJobs,
-          detail: jobDetails.find(
-            (detail) => detail.number === workflowJobs.job_number,
-          )!,
-          steps:
-            jobSteps.find((step) => step.build_num === workflowJobs.job_number)
-              ?.steps ?? [],
-        };
-      });
+      const jobs: Job[] = fetchableWorkflowJobs.map(
+        ({ workflowJob, detail }) => {
+          return {
+            ...workflowJob,
+            detail,
+            steps:
+              jobSteps.find((step) => step.build_num === workflowJob.job_number)
+                ?.steps ?? [],
+          };
+        },
+      );
 
       workflows.push({ ...workflow, jobs });
     }
@@ -421,12 +443,25 @@ export class CircleciClientV2 {
   }
 
   // https://circleci.com/docs/api/v2/#operation/getJobDetails
-  private async fetchJob(jobNumber: number, projectSlug: string) {
-    const res = await this.#http.get(
-      `v2/project/${projectSlug}/job/${jobNumber}`,
-      {},
-    );
-    return res.data as GetJobDetailsResponse;
+  private async fetchJob(
+    jobNumber: number,
+    projectSlug: string,
+  ): Promise<GetJobDetailsResponse | undefined> {
+    try {
+      const res = await this.#http.get(
+        `v2/project/${projectSlug}/job/${jobNumber}`,
+        {},
+      );
+      return res.data as GetJobDetailsResponse;
+    } catch (error) {
+      if (error instanceof HttpError && error.response?.status === 404) {
+        this.#logger.warn(
+          `Skip CircleCI job ${projectSlug}/${jobNumber} because job details returned 404.`,
+        );
+        return undefined;
+      }
+      throw error;
+    }
   }
 
   // https://circleci.com/docs/api/v1/#single-job

--- a/src/client/circleci_client_v2.ts
+++ b/src/client/circleci_client_v2.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { minimatch } from "minimatch";
 import type { Artifact, CustomReportArtifact } from "./artifact.js";
-import { createHttpClient, HttpError, type HttpClient } from "./http_client.js";
+import { createHttpClient, type HttpClient } from "./http_client.js";
 import type { CustomReportConfig } from "../config/schema.js";
 import type { ArgumentOptions } from "../arg_options.js";
 import type { Logger } from "tslog";
@@ -194,6 +194,7 @@ function hasJobDetail(job: {
 
 export type Workflow = ListWorkflowsByPipelineIdResponse["items"][0] & {
   jobs: Job[];
+  fetchableJobs: FilteredWorkflowJob[];
 };
 
 type Job = FilteredWorkflowJob & {
@@ -428,7 +429,11 @@ export class CircleciClientV2 {
         },
       );
 
-      workflows.push({ ...workflow, jobs });
+      workflows.push({
+        ...workflow,
+        jobs,
+        fetchableJobs: filteredWorkflowJobs,
+      });
     }
 
     return workflows;
@@ -447,21 +452,21 @@ export class CircleciClientV2 {
     jobNumber: number,
     projectSlug: string,
   ): Promise<GetJobDetailsResponse | undefined> {
-    try {
-      const res = await this.#http.get(
-        `v2/project/${projectSlug}/job/${jobNumber}`,
-        {},
+    const res = await this.#http.get(
+      `v2/project/${projectSlug}/job/${jobNumber}`,
+      {
+        validateStatus: (status) => {
+          return (status >= 200 && status < 300) || status === 404;
+        },
+      },
+    );
+    if (res.status === 404) {
+      this.#logger.warn(
+        `Skip CircleCI job ${projectSlug}/${jobNumber} because job details returned 404.`,
       );
-      return res.data as GetJobDetailsResponse;
-    } catch (error) {
-      if (error instanceof HttpError && error.response?.status === 404) {
-        this.#logger.warn(
-          `Skip CircleCI job ${projectSlug}/${jobNumber} because job details returned 404.`,
-        );
-        return undefined;
-      }
-      throw error;
+      return undefined;
     }
+    return res.data as GetJobDetailsResponse;
   }
 
   // https://circleci.com/docs/api/v1/#single-job
@@ -474,7 +479,7 @@ export class CircleciClientV2 {
   }
 
   async fetchWorkflowsTests(workflows: Workflow[]): Promise<JobTest[]> {
-    const jobs = workflows.flatMap((workflow) => workflow.jobs);
+    const jobs = workflows.flatMap((workflow) => workflow.fetchableJobs);
     return Promise.all(
       jobs.map((job) => {
         return this.fetchTests(job.job_number, job.project_slug);
@@ -495,7 +500,7 @@ export class CircleciClientV2 {
     customReportConfigs: CustomReportConfig[],
   ) {
     return await Promise.all(
-      workflow.jobs.map((job) => {
+      workflow.fetchableJobs.map((job) => {
         return this.fetchCustomReports(
           job.job_number,
           job.project_slug,

--- a/tests/client/circleci_client_v2.test.ts
+++ b/tests/client/circleci_client_v2.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { Logger } from "tslog";
 import { ArgumentOptions } from "../../src/arg_options.ts";
 import { CircleciClientV2 } from "../../src/client/circleci_client_v2.ts";
@@ -9,6 +9,10 @@ const options = new ArgumentOptions({
 });
 
 describe("CircleciClient", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe("new() with baseUrl", () => {
     it("should OK when undefined", async () => {
       expect(() => {
@@ -42,6 +46,63 @@ describe("CircleciClient", () => {
       expect(() => {
         new CircleciClientV2("DUMMY_TOKEN", logger, options, baseUrl);
       }).toThrow();
+    });
+  });
+
+  describe("fetchPipelineWorkflows", () => {
+    it("skips jobs when CircleCI job details return 404", async () => {
+      const fetch = vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+
+        if (url.includes("/v2/workflow/workflow-id/job")) {
+          return new Response(
+            JSON.stringify({
+              items: [
+                {
+                  dependencies: [],
+                  id: "job-id",
+                  job_number: 123,
+                  name: "test",
+                  project_slug: "gh/owner/repo",
+                  status: "success",
+                  type: "build",
+                },
+              ],
+              next_page_token: null,
+            }),
+          );
+        }
+
+        if (url.includes("/v2/project/gh/owner/repo/job/123")) {
+          return new Response(JSON.stringify({ message: "Not Found" }), {
+            status: 404,
+            statusText: "Not Found",
+          });
+        }
+
+        throw new Error(`Unexpected request: ${url}`);
+      });
+      vi.stubGlobal("fetch", fetch);
+
+      const client = new CircleciClientV2("DUMMY_TOKEN", logger, options);
+      const workflows = await client.fetchPipelineWorkflows({
+        id: "pipeline-id",
+        number: 1,
+        workflows: [
+          {
+            id: "workflow-id",
+            name: "ci",
+            project_slug: "gh/owner/repo",
+            status: "success",
+            pipeline_id: "pipeline-id",
+            pipeline_number: 1,
+            created_at: "2026-01-01T00:00:00Z",
+            stopped_at: "2026-01-01T00:01:00Z",
+          },
+        ],
+      } as never);
+
+      expect(workflows[0].jobs).toEqual([]);
     });
   });
 });

--- a/tests/client/circleci_client_v2.test.ts
+++ b/tests/client/circleci_client_v2.test.ts
@@ -294,6 +294,9 @@ describe("CircleciClient", () => {
       } as never);
 
       expect(workflows[0].jobs.map((job) => job.job_number)).toEqual([124]);
+      expect(workflows[0].fetchableJobs.map((job) => job.job_number)).toEqual([
+        123, 124,
+      ]);
 
       const tests = await client.fetchWorkflowsTests(workflows);
       expect(tests.map((job) => job.jobNumber)).toEqual([123, 124]);

--- a/tests/client/circleci_client_v2.test.ts
+++ b/tests/client/circleci_client_v2.test.ts
@@ -297,6 +297,9 @@ describe("CircleciClient", () => {
 
       const tests = await client.fetchWorkflowsTests(workflows);
       expect(tests.map((job) => job.jobNumber)).toEqual([123, 124]);
+      expect(
+        tests.flatMap((job) => job.tests.map((test) => test.name)),
+      ).toEqual(["still exported", "also exported"]);
 
       const customReports = await client.fetchWorkflowCustomReports(
         workflows[0],
@@ -308,6 +311,13 @@ describe("CircleciClient", () => {
           (jobReports.get("report") ?? []).map((artifact) => artifact.path),
         ),
       ).toEqual([["reports/job-123.json"], ["reports/job-124.json"]]);
+      expect(
+        customReports.map((jobReports) =>
+          (jobReports.get("report") ?? []).map((artifact) =>
+            JSON.parse(new TextDecoder().decode(artifact.data)),
+          ),
+        ),
+      ).toEqual([[{ job: 123 }], [{ job: 124 }]]);
     });
   });
 });

--- a/tests/client/circleci_client_v2.test.ts
+++ b/tests/client/circleci_client_v2.test.ts
@@ -10,6 +10,7 @@ const options = new ArgumentOptions({
 
 describe("CircleciClient", () => {
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -103,6 +104,210 @@ describe("CircleciClient", () => {
       } as never);
 
       expect(workflows[0].jobs).toEqual([]);
+    });
+
+    it("keeps exporting tests and custom reports for jobs whose details are missing", async () => {
+      const fetch = vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+
+        if (url.includes("/v2/workflow/workflow-id/job")) {
+          return new Response(
+            JSON.stringify({
+              items: [
+                {
+                  dependencies: [],
+                  id: "job-id-1",
+                  job_number: 123,
+                  name: "test-missing-detail",
+                  project_slug: "gh/owner/repo",
+                  started_at: "2026-01-01T00:00:10Z",
+                  status: "success",
+                  stopped_at: "2026-01-01T00:00:20Z",
+                  type: "build",
+                },
+                {
+                  dependencies: [],
+                  id: "job-id-2",
+                  job_number: 124,
+                  name: "test-with-detail",
+                  project_slug: "gh/owner/repo",
+                  started_at: "2026-01-01T00:00:30Z",
+                  status: "success",
+                  stopped_at: "2026-01-01T00:00:40Z",
+                  type: "build",
+                },
+              ],
+              next_page_token: null,
+            }),
+          );
+        }
+
+        if (url.includes("/v2/project/gh/owner/repo/job/123")) {
+          return new Response(JSON.stringify({ message: "Not Found" }), {
+            status: 404,
+            statusText: "Not Found",
+          });
+        }
+
+        if (url.includes("/v2/project/gh/owner/repo/job/124")) {
+          return new Response(
+            JSON.stringify({
+              contexts: [],
+              created_at: "2026-01-01T00:00:00Z",
+              duration: 1000,
+              executor: {
+                resource_class: "medium",
+                type: "docker",
+              },
+              latest_workflow: {
+                id: "workflow-id",
+                name: "ci",
+              },
+              messages: [],
+              name: "test-with-detail",
+              number: 124,
+              organization: {
+                name: "owner",
+              },
+              parallel_runs: [],
+              parallelism: 1,
+              pipeline: {
+                id: "pipeline-id",
+              },
+              project: {
+                external_url: "https://github.com/owner/repo",
+                name: "repo",
+                slug: "gh/owner/repo",
+              },
+              queued_at: "2026-01-01T00:00:00Z",
+              started_at: "2026-01-01T00:00:30Z",
+              status: "success",
+              stopped_at: "2026-01-01T00:00:40Z",
+              web_url: "https://circleci.com/gh/owner/repo/124",
+            }),
+          );
+        }
+
+        if (url.includes("/v1.1/project/gh/owner/repo/124")) {
+          return new Response(
+            JSON.stringify({
+              build_num: 124,
+              steps: [],
+            }),
+          );
+        }
+
+        if (url.includes("/v2/project/gh/owner/repo/123/tests")) {
+          return new Response(
+            JSON.stringify({
+              items: [
+                {
+                  classname: "MissingDetailTest",
+                  file: "missing.test.ts",
+                  message: null,
+                  name: "still exported",
+                  result: "success",
+                  run_time: 1,
+                  source: "unknown",
+                },
+              ],
+              next_page_token: null,
+            }),
+          );
+        }
+
+        if (url.includes("/v2/project/gh/owner/repo/124/tests")) {
+          return new Response(
+            JSON.stringify({
+              items: [
+                {
+                  classname: "DetailedTest",
+                  file: "detailed.test.ts",
+                  message: null,
+                  name: "also exported",
+                  result: "success",
+                  run_time: 1,
+                  source: "unknown",
+                },
+              ],
+              next_page_token: null,
+            }),
+          );
+        }
+
+        if (url.includes("/v2/project/gh/owner/repo/123/artifacts")) {
+          return new Response(
+            JSON.stringify({
+              items: [
+                {
+                  path: "reports/job-123.json",
+                  url: "https://example.com/job-123.json",
+                },
+              ],
+              next_page_token: null,
+            }),
+          );
+        }
+
+        if (url.includes("/v2/project/gh/owner/repo/124/artifacts")) {
+          return new Response(
+            JSON.stringify({
+              items: [
+                {
+                  path: "reports/job-124.json",
+                  url: "https://example.com/job-124.json",
+                },
+              ],
+              next_page_token: null,
+            }),
+          );
+        }
+
+        if (url === "https://example.com/job-123.json") {
+          return new Response(JSON.stringify({ job: 123 }));
+        }
+
+        if (url === "https://example.com/job-124.json") {
+          return new Response(JSON.stringify({ job: 124 }));
+        }
+
+        throw new Error(`Unexpected request: ${url}`);
+      });
+      vi.stubGlobal("fetch", fetch);
+
+      const client = new CircleciClientV2("DUMMY_TOKEN", logger, options);
+      const workflows = await client.fetchPipelineWorkflows({
+        id: "pipeline-id",
+        number: 1,
+        workflows: [
+          {
+            id: "workflow-id",
+            name: "ci",
+            project_slug: "gh/owner/repo",
+            status: "success",
+            pipeline_id: "pipeline-id",
+            pipeline_number: 1,
+            created_at: "2026-01-01T00:00:00Z",
+            stopped_at: "2026-01-01T00:01:00Z",
+          },
+        ],
+      } as never);
+
+      expect(workflows[0].jobs.map((job) => job.job_number)).toEqual([124]);
+
+      const tests = await client.fetchWorkflowsTests(workflows);
+      expect(tests.map((job) => job.jobNumber)).toEqual([123, 124]);
+
+      const customReports = await client.fetchWorkflowCustomReports(
+        workflows[0],
+        [{ name: "report", paths: ["reports/*.json"] }] as never,
+      );
+      expect(customReports).toHaveLength(2);
+      expect(
+        customReports.map((jobReports) =>
+          (jobReports.get("report") ?? []).map((artifact) => artifact.path),
+        ),
+      ).toEqual([["reports/job-123.json"], ["reports/job-124.json"]]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- skip CircleCI workflow jobs whose job detail endpoint returns 404
- keep exporting the rest of the workflow data
- add a regression test for missing job details

## Validation
- npm run check
- npm run biome:ci
- npx vitest --run tests/client/circleci_client_v2.test.ts