### PR TITLE
Skip missing CircleCI test and artifact data

### DIFF
--- a/src/client/circleci_client_v2.ts
+++ b/src/client/circleci_client_v2.ts
@@ -1,7 +1,11 @@
 import path from "node:path";
 import { minimatch } from "minimatch";
 import type { Artifact, CustomReportArtifact } from "./artifact.js";
-import { createHttpClient, type HttpClient } from "./http_client.js";
+import {
+  createHttpClient,
+  type HttpClient,
+  type RequestConfig,
+} from "./http_client.js";
 import type { CustomReportConfig } from "../config/schema.js";
 import type { ArgumentOptions } from "../arg_options.js";
 import type { Logger } from "tslog";
@@ -31,6 +35,28 @@ type V2ApiResponse = {
   items: unknown[];
   next_page_token: string | null;
 };
+
+type FetchV2ApiOptions = {
+  validateStatus?: RequestConfig["validateStatus"];
+  notFoundMessage?: string;
+};
+
+function isSuccessfulStatus(status: number): boolean {
+  return status >= 200 && status < 300;
+}
+
+function getFetchV2ApiValidateStatus(
+  options?: FetchV2ApiOptions,
+): RequestConfig["validateStatus"] | undefined {
+  if (!options?.notFoundMessage) {
+    return options?.validateStatus;
+  }
+
+  const validateStatus = options.validateStatus ?? isSuccessfulStatus;
+  return function validateStatusOrNotFound(status: number): boolean {
+    return validateStatus(status) || status === 404;
+  };
+}
 
 type ListPipelinesForProjectResponse = {
   items: {
@@ -302,38 +328,21 @@ export class CircleciClientV2 {
   private async fetchV2Api<T extends V2ApiResponse>(
     url: string,
     requestParams?: { [key: string]: unknown },
+    options?: FetchV2ApiOptions,
   ): Promise<T["items"]> {
     const items: T["items"] = [];
-    for (let pageToken = undefined; pageToken !== null; ) {
+    const validateStatus = getFetchV2ApiValidateStatus(options);
+    let pageToken: T["next_page_token"] | undefined;
+    while (pageToken !== null) {
       const res = await this.#http.get(url, {
         params: {
           ...requestParams,
           "page-token": pageToken,
         },
+        validateStatus,
       });
-      const data = res.data as T;
-      items.push(...data.items);
-      pageToken = data.next_page_token;
-    }
-    return items;
-  }
-
-  private async fetchV2ApiOrEmptyOn404<T extends V2ApiResponse>(
-    url: string,
-    notFoundMessage: string,
-  ): Promise<T["items"]> {
-    const items: T["items"] = [];
-    let pageToken: T["next_page_token"] | undefined;
-    while (pageToken !== null) {
-      const res = await this.#http.get(url, {
-        params: {
-          "page-token": pageToken,
-        },
-        validateStatus: (status) =>
-          (status >= 200 && status < 300) || status === 404,
-      });
-      if (res.status === 404) {
-        this.#logger.warn(notFoundMessage);
+      if (res.status === 404 && options?.notFoundMessage) {
+        this.#logger.warn(options.notFoundMessage);
         return [];
       }
       const data = res.data as T;
@@ -513,9 +522,12 @@ export class CircleciClientV2 {
 
   // https://circleci.com/docs/api/v2/#operation/getTests
   async fetchTests(jobNumber: number, projectSlug: string): Promise<JobTest> {
-    const tests = await this.fetchV2ApiOrEmptyOn404<TestResponse>(
+    const tests = await this.fetchV2Api<TestResponse>(
       `v2/project/${projectSlug}/${jobNumber}/tests`,
-      `Skip CircleCI tests for job ${projectSlug}/${jobNumber} because tests returned 404.`,
+      undefined,
+      {
+        notFoundMessage: `Skip CircleCI tests for job ${projectSlug}/${jobNumber} because tests returned 404.`,
+      },
     );
     return { tests, jobNumber };
   }
@@ -570,9 +582,12 @@ export class CircleciClientV2 {
     jobNumber: number,
     projectSlug: string,
   ): Promise<ArtifactItem[]> {
-    const artifacts = await this.fetchV2ApiOrEmptyOn404<ArtifactsResponse>(
+    const artifacts = await this.fetchV2Api<ArtifactsResponse>(
       `v2/project/${projectSlug}/${jobNumber}/artifacts`,
-      `Skip CircleCI artifacts for job ${projectSlug}/${jobNumber} because artifacts returned 404.`,
+      undefined,
+      {
+        notFoundMessage: `Skip CircleCI artifacts for job ${projectSlug}/${jobNumber} because artifacts returned 404.`,
+      },
     );
     return artifacts;
   }

--- a/src/client/circleci_client_v2.ts
+++ b/src/client/circleci_client_v2.ts
@@ -318,6 +318,31 @@ export class CircleciClientV2 {
     return items;
   }
 
+  private async fetchV2ApiOrEmptyOn404<T extends V2ApiResponse>(
+    url: string,
+    notFoundMessage: string,
+  ): Promise<T["items"]> {
+    const items: T["items"] = [];
+    let pageToken: T["next_page_token"] | undefined;
+    while (pageToken !== null) {
+      const res = await this.#http.get(url, {
+        params: {
+          "page-token": pageToken,
+        },
+        validateStatus: (status) =>
+          (status >= 200 && status < 300) || status === 404,
+      });
+      if (res.status === 404) {
+        this.#logger.warn(notFoundMessage);
+        return [];
+      }
+      const data = res.data as T;
+      items.push(...data.items);
+      pageToken = data.next_page_token;
+    }
+    return items;
+  }
+
   // https://circleci.com/docs/api/v2/#operation/listPipelines
   // https://circleci.com/docs/api/v2/#operation/listWorkflowsByPipelineId
   async fetchWorkflowRuns(
@@ -488,8 +513,9 @@ export class CircleciClientV2 {
 
   // https://circleci.com/docs/api/v2/#operation/getTests
   async fetchTests(jobNumber: number, projectSlug: string): Promise<JobTest> {
-    const tests = await this.fetchV2Api<TestResponse>(
+    const tests = await this.fetchV2ApiOrEmptyOn404<TestResponse>(
       `v2/project/${projectSlug}/${jobNumber}/tests`,
+      `Skip CircleCI tests for job ${projectSlug}/${jobNumber} because tests returned 404.`,
     );
     return { tests, jobNumber };
   }
@@ -544,8 +570,9 @@ export class CircleciClientV2 {
     jobNumber: number,
     projectSlug: string,
   ): Promise<ArtifactItem[]> {
-    const artifacts = await this.fetchV2Api<ArtifactsResponse>(
+    const artifacts = await this.fetchV2ApiOrEmptyOn404<ArtifactsResponse>(
       `v2/project/${projectSlug}/${jobNumber}/artifacts`,
+      `Skip CircleCI artifacts for job ${projectSlug}/${jobNumber} because artifacts returned 404.`,
     );
     return artifacts;
   }

--- a/tests/client/circleci_client_v2.test.ts
+++ b/tests/client/circleci_client_v2.test.ts
@@ -322,5 +322,72 @@ describe("CircleciClient", () => {
         ),
       ).toEqual([[{ job: 123 }], [{ job: 124 }]]);
     });
+
+    it("returns empty tests and warns when CircleCI tests return 404", async () => {
+      const fetch = vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+
+        if (url.includes("/v2/project/gh/owner/repo/123/tests")) {
+          return new Response(JSON.stringify({ message: "Not Found" }), {
+            status: 404,
+            statusText: "Not Found",
+          });
+        }
+
+        throw new Error(`Unexpected request: ${url}`);
+      });
+      vi.stubGlobal("fetch", fetch);
+
+      const circleciLogger = logger.getSubLogger({
+        name: CircleciClientV2.name,
+      });
+      const warn = vi
+        .spyOn(circleciLogger, "warn")
+        .mockImplementation(() => undefined);
+      vi.spyOn(logger, "getSubLogger").mockReturnValue(circleciLogger);
+
+      const client = new CircleciClientV2("DUMMY_TOKEN", logger, options);
+      const tests = await client.fetchTests(123, "gh/owner/repo");
+      expect(tests).toEqual({ tests: [], jobNumber: 123 });
+      expect(warn).toHaveBeenCalledWith(
+        "Skip CircleCI tests for job gh/owner/repo/123 because tests returned 404.",
+      );
+    });
+
+    it("returns empty custom reports and warns when CircleCI artifacts return 404", async () => {
+      const fetch = vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+
+        if (url.includes("/v2/project/gh/owner/repo/123/artifacts")) {
+          return new Response(JSON.stringify({ message: "Not Found" }), {
+            status: 404,
+            statusText: "Not Found",
+          });
+        }
+
+        throw new Error(`Unexpected request: ${url}`);
+      });
+      vi.stubGlobal("fetch", fetch);
+
+      const circleciLogger = logger.getSubLogger({
+        name: CircleciClientV2.name,
+      });
+      const warn = vi
+        .spyOn(circleciLogger, "warn")
+        .mockImplementation(() => undefined);
+      vi.spyOn(logger, "getSubLogger").mockReturnValue(circleciLogger);
+
+      const client = new CircleciClientV2("DUMMY_TOKEN", logger, options);
+      const customReports = await client.fetchWorkflowCustomReports(
+        {
+          fetchableJobs: [{ job_number: 123, project_slug: "gh/owner/repo" }],
+        } as never,
+        [{ name: "report", paths: ["reports/*.json"] }] as never,
+      );
+      expect(customReports).toEqual([new Map([["report", []]])]);
+      expect(warn).toHaveBeenCalledWith(
+        "Skip CircleCI artifacts for job gh/owner/repo/123 because artifacts returned 404.",
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Treat 404 responses from CircleCI test and artifact endpoints as missing job data instead of failing the runner.
- Reuse the existing CircleCI v2 pagination helper for the 404-as-empty behavior.
- Add client coverage for missing test and artifact responses.

## Test plan
- [x] npm run biome:ci
- [x] npm run check
- [x] npm test
- [x] Run CIAnalyzer locally with the real deployment configuration and `--only-services circleci`
