### PR TITLE
Handle non-ZIP GitHub Actions artifacts

### DIFF
--- a/src/client/github_artifact.ts
+++ b/src/client/github_artifact.ts
@@ -1,0 +1,71 @@
+import { minimatch } from "minimatch";
+import type { Artifact } from "./artifact.js";
+
+const ZIP_SIGNATURES = [
+  [0x50, 0x4b, 0x03, 0x04],
+  [0x50, 0x4b, 0x05, 0x06],
+  [0x50, 0x4b, 0x07, 0x08],
+] as const;
+
+export type GithubArtifactFormat = "zip" | "file";
+
+function hasZipSignature(data: ArrayBuffer): boolean {
+  const bytes = new Uint8Array(data);
+  return ZIP_SIGNATURES.some((signature) => {
+    return signature.every((byte, index) => bytes[index] === byte);
+  });
+}
+
+function stripQuotes(value: string): string {
+  return value.replace(/^"(.*)"$/, "$1").trim();
+}
+
+function parseContentDispositionFilename(
+  contentDisposition: string,
+): string | undefined {
+  const utf8FilenameMatch = contentDisposition.match(
+    /filename\*\s*=\s*UTF-8''([^;]+)/i,
+  );
+  if (utf8FilenameMatch?.[1]) {
+    return decodeURIComponent(stripQuotes(utf8FilenameMatch[1]));
+  }
+
+  const filenameMatch = contentDisposition.match(/filename\s*=\s*([^;]+)/i);
+  if (filenameMatch?.[1]) {
+    return stripQuotes(filenameMatch[1]);
+  }
+
+  return undefined;
+}
+
+export function detectGithubArtifactFormat(
+  data: ArrayBuffer,
+): GithubArtifactFormat {
+  return hasZipSignature(data) ? "zip" : "file";
+}
+
+export function resolveGithubArtifactPath(
+  headers: Headers,
+  fallbackName: string,
+): string {
+  const contentDisposition = headers.get("content-disposition");
+  if (!contentDisposition) return fallbackName;
+
+  return parseContentDispositionFilename(contentDisposition) ?? fallbackName;
+}
+
+function matchesGithubArtifactPath(path: string, globs: string[]): boolean {
+  return globs.some((glob) => minimatch(path, glob));
+}
+
+export function toDirectArtifact(
+  path: string,
+  data: ArrayBuffer,
+  globs: string[],
+): Artifact | undefined {
+  if (!matchesGithubArtifactPath(path, globs)) return undefined;
+  return {
+    path,
+    data,
+  };
+}

--- a/src/client/github_artifact.ts
+++ b/src/client/github_artifact.ts
@@ -6,6 +6,8 @@ const ZIP_SIGNATURES = [
   [0x50, 0x4b, 0x05, 0x06],
   [0x50, 0x4b, 0x07, 0x08],
 ] as const;
+const UTF8_FILENAME_PATTERN = /filename\*\s*=\s*UTF-8''([^;]+)/i;
+const FILENAME_PATTERN = /filename\s*=\s*([^;]+)/i;
 
 export type GithubArtifactFormat = "zip" | "file";
 
@@ -17,33 +19,56 @@ function hasZipSignature(data: ArrayBuffer): boolean {
 }
 
 function stripQuotes(value: string): string {
-  return value.replace(/^"(.*)"$/, "$1").trim();
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('"') || !trimmed.endsWith('"')) {
+    return trimmed;
+  }
+
+  return trimmed.slice(1, -1);
+}
+
+function getContentDispositionFilename(
+  contentDisposition: string,
+  pattern: RegExp,
+): string | undefined {
+  const filename = contentDisposition.match(pattern)?.[1];
+  if (!filename) {
+    return undefined;
+  }
+
+  return stripQuotes(filename);
 }
 
 function parseContentDispositionFilename(
   contentDisposition: string,
 ): string | undefined {
-  const utf8FilenameMatch = contentDisposition.match(
-    /filename\*\s*=\s*UTF-8''([^;]+)/i,
+  const utf8Filename = getContentDispositionFilename(
+    contentDisposition,
+    UTF8_FILENAME_PATTERN,
   );
-  if (utf8FilenameMatch?.[1]) {
-    return decodeURIComponent(stripQuotes(utf8FilenameMatch[1]));
+  if (utf8Filename) {
+    return decodeURIComponent(utf8Filename);
   }
 
-  const filenameMatch = contentDisposition.match(/filename\s*=\s*([^;]+)/i);
-  if (filenameMatch?.[1]) {
-    return stripQuotes(filenameMatch[1]);
-  }
-
-  return undefined;
+  return getContentDispositionFilename(contentDisposition, FILENAME_PATTERN);
 }
 
+/**
+ * GitHub's artifact metadata and headers are not reliable enough to identify
+ * whether a payload is really a ZIP, so inspect the payload bytes directly
+ * before deciding whether it is safe to pass to AdmZip.
+ */
 export function detectGithubArtifactFormat(
   data: ArrayBuffer,
 ): GithubArtifactFormat {
   return hasZipSignature(data) ? "zip" : "file";
 }
 
+/**
+ * Non-ZIP artifacts should still be matched against the existing path globs.
+ * Prefer the download response filename because GitHub can return a more
+ * specific name than the artifact's logical name from the listing API.
+ */
 export function resolveGithubArtifactPath(
   headers: Headers,
   fallbackName: string,
@@ -58,6 +83,10 @@ function matchesGithubArtifactPath(path: string, globs: string[]): boolean {
   return globs.some((glob) => minimatch(path, glob));
 }
 
+/**
+ * Reuse the current path-glob configuration for non-ZIP artifacts instead of
+ * introducing a separate artifact-name config surface.
+ */
 export function toDirectArtifact(
   path: string,
   data: ArrayBuffer,

--- a/src/client/github_client.ts
+++ b/src/client/github_client.ts
@@ -16,6 +16,7 @@ import {
 // Oktokit document: https://octokit.github.io/rest.js/v18#actions
 
 const DEBUG_PER_PAGE = 10;
+const GITHUB_API_VERSION = "2022-11-28";
 
 export type WorkflowItem =
   RestEndpointMethodTypes["actions"]["listRepoWorkflows"]["response"]["data"]["workflows"][0];
@@ -35,6 +36,7 @@ type GithubOctokit = Pick<Octokit, "log"> & {
     | "listWorkflowRunArtifacts"
   >;
   repos: Pick<Octokit["repos"], "listTags">;
+  request: Octokit["request"];
 };
 
 type DownloadedArtifactResponse = {
@@ -49,15 +51,24 @@ type DownloadedArtifact = {
 };
 
 type WorkflowArtifactToDownload = {
+  id: number;
   name: string;
-  archiveDownloadUrl: string;
 };
+
+type ArtifactDownloadUrlResolver = (
+  owner: string,
+  repo: string,
+  artifactId: number,
+) => Promise<string>;
+
+type ArtifactDownloader = (
+  artifactDownloadUrl: string,
+) => Promise<DownloadedArtifactResponse>;
 
 type GithubClientDependencies = {
   octokit?: GithubOctokit;
-  artifactDownloader?: (
-    archiveDownloadUrl: string,
-  ) => Promise<DownloadedArtifactResponse>;
+  artifactDownloadUrlResolver?: ArtifactDownloadUrlResolver;
+  artifactDownloader?: ArtifactDownloader;
 };
 
 const isExpiredArtifactError = (
@@ -72,11 +83,9 @@ const isExpiredArtifactError = (
 };
 
 export class GithubClient {
-  #artifactDownloader: (
-    archiveDownloadUrl: string,
-  ) => Promise<DownloadedArtifactResponse>;
+  #artifactDownloadUrlResolver: ArtifactDownloadUrlResolver;
+  #artifactDownloader: ArtifactDownloader;
   #octokit: GithubOctokit;
-  #token: string;
   constructor(
     token: string,
     private options: ArgumentOptions,
@@ -84,7 +93,6 @@ export class GithubClient {
     deps: GithubClientDependencies = {},
   ) {
     const MyOctokit = Octokit.plugin(throttling, retry);
-    this.#token = token;
     this.#octokit =
       deps.octokit ??
       new MyOctokit({
@@ -115,20 +123,49 @@ export class GithubClient {
           },
         },
       });
+    this.#artifactDownloadUrlResolver =
+      deps.artifactDownloadUrlResolver ??
+      this.resolveArtifactDownloadUrl.bind(this);
     this.#artifactDownloader =
       deps.artifactDownloader ?? this.downloadArtifactFromUrl.bind(this);
   }
 
-  private createArtifactDownloadHeaders(): Headers {
-    const headers = new Headers({
-      Accept: "application/vnd.github+json",
-      "X-GitHub-Api-Version": "2022-11-28",
-    });
-    if (this.#token) {
-      headers.set("Authorization", `Bearer ${this.#token}`);
+  private async resolveArtifactDownloadUrl(
+    owner: string,
+    repo: string,
+    artifactId: number,
+  ): Promise<string> {
+    const response = await this.#octokit.request(
+      "GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}",
+      {
+        owner,
+        repo,
+        artifact_id: artifactId,
+        archive_format: "zip",
+        headers: {
+          "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        },
+        request: {
+          parseSuccessResponseBody: false,
+          redirect: "manual",
+        },
+      },
+    );
+
+    const location = response.headers.location;
+    if (!location) {
+      throw new Error(
+        `Artifact download URL was missing for ${owner}/${repo} artifact=${artifactId}`,
+      );
     }
 
-    return headers;
+    return location;
+  }
+
+  private createArtifactDownloadHeaders(): Headers {
+    return new Headers({
+      Accept: "application/octet-stream",
+    });
   }
 
   private toDownloadedArtifact(
@@ -143,9 +180,9 @@ export class GithubClient {
   }
 
   private async downloadArtifactFromUrl(
-    archiveDownloadUrl: string,
+    artifactDownloadUrl: string,
   ): Promise<DownloadedArtifactResponse> {
-    const response = await fetch(archiveDownloadUrl, {
+    const response = await fetch(artifactDownloadUrl, {
       headers: this.createArtifactDownloadHeaders(),
     });
     if (!response.ok) {
@@ -169,10 +206,14 @@ export class GithubClient {
     artifact: WorkflowArtifactToDownload,
   ): Promise<DownloadedArtifact | undefined> {
     try {
-      const response = await this.#artifactDownloader(
-        artifact.archiveDownloadUrl,
+      const { id, name } = artifact;
+      const artifactDownloadUrl = await this.#artifactDownloadUrlResolver(
+        owner,
+        repo,
+        id,
       );
-      return this.toDownloadedArtifact(artifact.name, response);
+      const response = await this.#artifactDownloader(artifactDownloadUrl);
+      return this.toDownloadedArtifact(name, response);
     } catch (error) {
       if (isExpiredArtifactError(error)) {
         this.#octokit.log.warn(
@@ -272,8 +313,8 @@ export class GithubClient {
             repo,
             runId,
             {
+              id: artifact.id,
               name: artifact.name,
-              archiveDownloadUrl: artifact.archive_download_url,
             },
           );
 

--- a/src/client/github_client.ts
+++ b/src/client/github_client.ts
@@ -39,6 +39,8 @@ type GithubOctokit = Pick<Octokit, "log"> & {
   request: Octokit["request"];
 };
 
+type ArtifactDownloadOctokit = Pick<Octokit, "request">;
+
 type DownloadedArtifactResponse = {
   data: ArrayBuffer;
   headers: Headers;
@@ -61,14 +63,10 @@ type ArtifactDownloadUrlResolver = (
   artifactId: number,
 ) => Promise<string>;
 
-type ArtifactDownloader = (
-  artifactDownloadUrl: string,
-) => Promise<DownloadedArtifactResponse>;
-
 type GithubClientDependencies = {
   octokit?: GithubOctokit;
+  artifactDownloadOctokit?: ArtifactDownloadOctokit;
   artifactDownloadUrlResolver?: ArtifactDownloadUrlResolver;
-  artifactDownloader?: ArtifactDownloader;
 };
 
 const isExpiredArtifactError = (
@@ -84,7 +82,7 @@ const isExpiredArtifactError = (
 
 export class GithubClient {
   #artifactDownloadUrlResolver: ArtifactDownloadUrlResolver;
-  #artifactDownloader: ArtifactDownloader;
+  #artifactDownloadOctokit: ArtifactDownloadOctokit;
   #octokit: GithubOctokit;
   constructor(
     token: string,
@@ -123,11 +121,15 @@ export class GithubClient {
           },
         },
       });
+    const RetryableBlobOctokit = Octokit.plugin(retry);
+    this.#artifactDownloadOctokit =
+      deps.artifactDownloadOctokit ??
+      new RetryableBlobOctokit({
+        log: options.debug ? console : undefined,
+      });
     this.#artifactDownloadUrlResolver =
       deps.artifactDownloadUrlResolver ??
       this.resolveArtifactDownloadUrl.bind(this);
-    this.#artifactDownloader =
-      deps.artifactDownloader ?? this.downloadArtifactFromUrl.bind(this);
   }
 
   private async resolveArtifactDownloadUrl(
@@ -162,12 +164,6 @@ export class GithubClient {
     return location;
   }
 
-  private createArtifactDownloadHeaders(): Headers {
-    return new Headers({
-      Accept: "application/octet-stream",
-    });
-  }
-
   private toDownloadedArtifact(
     artifactName: string,
     response: DownloadedArtifactResponse,
@@ -182,20 +178,12 @@ export class GithubClient {
   private async downloadArtifactFromUrl(
     artifactDownloadUrl: string,
   ): Promise<DownloadedArtifactResponse> {
-    const response = await fetch(artifactDownloadUrl, {
-      headers: this.createArtifactDownloadHeaders(),
-    });
-    if (!response.ok) {
-      const error = new Error(
-        `Failed to download artifact: ${response.status} ${response.statusText}`,
-      ) as Error & { status?: number };
-      error.status = response.status;
-      throw error;
-    }
-
+    const { data, headers } = await this.#artifactDownloadOctokit.request(
+      `GET ${artifactDownloadUrl}`,
+    );
     return {
-      data: await response.arrayBuffer(),
-      headers: response.headers,
+      data: data as ArrayBuffer,
+      headers: new Headers(headers as Record<string, string>),
     };
   }
 
@@ -212,8 +200,10 @@ export class GithubClient {
         repo,
         id,
       );
-      const response = await this.#artifactDownloader(artifactDownloadUrl);
-      return this.toDownloadedArtifact(name, response);
+      return this.toDownloadedArtifact(
+        name,
+        await this.downloadArtifactFromUrl(artifactDownloadUrl),
+      );
     } catch (error) {
       if (isExpiredArtifactError(error)) {
         this.#octokit.log.warn(

--- a/src/client/github_client.ts
+++ b/src/client/github_client.ts
@@ -6,6 +6,12 @@ import { minBy } from "lodash-es";
 import { ZipExtractor } from "../zip_extractor.js";
 import type { CustomReportConfig } from "../config/schema.js";
 import type { ArgumentOptions } from "../arg_options.js";
+import {
+  detectGithubArtifactFormat,
+  resolveGithubArtifactPath,
+  toDirectArtifact,
+  type GithubArtifactFormat,
+} from "./github_artifact.js";
 
 // Oktokit document: https://octokit.github.io/rest.js/v18#actions
 
@@ -20,6 +26,40 @@ type RunStatus = "queued" | "in_progress" | "completed";
 
 export type RepositoryTagMap = Map<string, string>;
 
+type GithubOctokit = Pick<Octokit, "log"> & {
+  actions: Pick<
+    Octokit["actions"],
+    | "listWorkflowRuns"
+    | "listRepoWorkflows"
+    | "listJobsForWorkflowRun"
+    | "listWorkflowRunArtifacts"
+  >;
+  repos: Pick<Octokit["repos"], "listTags">;
+};
+
+type DownloadedArtifactResponse = {
+  data: ArrayBuffer;
+  headers: Headers;
+};
+
+type DownloadedArtifact = {
+  data: ArrayBuffer;
+  format: GithubArtifactFormat;
+  path: string;
+};
+
+type WorkflowArtifactToDownload = {
+  name: string;
+  archiveDownloadUrl: string;
+};
+
+type GithubClientDependencies = {
+  octokit?: GithubOctokit;
+  artifactDownloader?: (
+    archiveDownloadUrl: string,
+  ) => Promise<DownloadedArtifactResponse>;
+};
+
 const isExpiredArtifactError = (
   error: unknown,
 ): error is { status: number } => {
@@ -32,55 +72,107 @@ const isExpiredArtifactError = (
 };
 
 export class GithubClient {
-  #octokit: Octokit;
+  #artifactDownloader: (
+    archiveDownloadUrl: string,
+  ) => Promise<DownloadedArtifactResponse>;
+  #octokit: GithubOctokit;
+  #token: string;
   constructor(
     token: string,
     private options: ArgumentOptions,
     baseUrl?: string,
+    deps: GithubClientDependencies = {},
   ) {
     const MyOctokit = Octokit.plugin(throttling, retry);
-    this.#octokit = new MyOctokit({
-      auth: token,
-      baseUrl: baseUrl ? baseUrl : "https://api.github.com",
-      log: options.debug ? console : undefined,
-      throttle: {
-        onRateLimit: (retryAfter, options, _octokit, retryCount) => {
-          this.#octokit.log.warn(
-            `Request quota exhausted for request ${options.method} ${options.url}`,
-          );
-          // Retry twice after hitting a rate limit error, then give up
-          if (retryCount <= 2) {
-            this.#octokit.log.warn(`Retrying after ${retryAfter} seconds!`);
-            return true;
-          }
+    this.#token = token;
+    this.#octokit =
+      deps.octokit ??
+      new MyOctokit({
+        auth: token,
+        baseUrl: baseUrl ?? "https://api.github.com",
+        log: options.debug ? console : undefined,
+        throttle: {
+          onRateLimit: (retryAfter, options, _octokit, retryCount) => {
+            this.#octokit.log.warn(
+              `Request quota exhausted for request ${options.method} ${options.url}`,
+            );
+            // Retry twice after hitting a rate limit error, then give up
+            if (retryCount <= 2) {
+              this.#octokit.log.warn(`Retrying after ${retryAfter} seconds!`);
+              return true;
+            }
+          },
+          onSecondaryRateLimit: (
+            _retryAfter,
+            options,
+            _octokit,
+            _retryCount,
+          ) => {
+            // does not retry, only logs a warning
+            this.#octokit.log.warn(
+              `Abuse detected for request ${options.method} ${options.url}`,
+            );
+          },
         },
-        onSecondaryRateLimit: (_retryAfter, options, _octokit, _retryCount) => {
-          // does not retry, only logs a warning
-          this.#octokit.log.warn(
-            `Abuse detected for request ${options.method} ${options.url}`,
-          );
-        },
-      },
+      });
+    this.#artifactDownloader =
+      deps.artifactDownloader ?? this.downloadArtifactFromUrl.bind(this);
+  }
+
+  private createArtifactDownloadHeaders(): Headers {
+    const headers = new Headers({
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
     });
+    if (this.#token) {
+      headers.set("Authorization", `Bearer ${this.#token}`);
+    }
+
+    return headers;
+  }
+
+  private toDownloadedArtifact(
+    artifactName: string,
+    response: DownloadedArtifactResponse,
+  ): DownloadedArtifact {
+    return {
+      data: response.data,
+      format: detectGithubArtifactFormat(response.data),
+      path: resolveGithubArtifactPath(response.headers, artifactName),
+    };
+  }
+
+  private async downloadArtifactFromUrl(
+    archiveDownloadUrl: string,
+  ): Promise<DownloadedArtifactResponse> {
+    const response = await fetch(archiveDownloadUrl, {
+      headers: this.createArtifactDownloadHeaders(),
+    });
+    if (!response.ok) {
+      const error = new Error(
+        `Failed to download artifact: ${response.status} ${response.statusText}`,
+      ) as Error & { status?: number };
+      error.status = response.status;
+      throw error;
+    }
+
+    return {
+      data: await response.arrayBuffer(),
+      headers: response.headers,
+    };
   }
 
   private async downloadArtifact(
     owner: string,
     repo: string,
     runId: number,
-    artifact: {
-      id: number;
-      name: string;
-    },
-  ): Promise<ArrayBuffer | undefined> {
+    artifact: WorkflowArtifactToDownload,
+  ): Promise<DownloadedArtifact | undefined> {
     try {
-      const response = await this.#octokit.actions.downloadArtifact({
-        owner,
-        repo,
-        artifact_id: artifact.id,
-        archive_format: "zip",
-      });
-      return response.data as ArrayBuffer;
+      const response = await this.#artifactDownloader(
+        artifact.archiveDownloadUrl,
+      );
+      return this.toDownloadedArtifact(artifact.name, response);
     } catch (error) {
       if (isExpiredArtifactError(error)) {
         this.#octokit.log.warn(
@@ -163,43 +255,65 @@ export class GithubClient {
     runId: number,
     globs: string[],
   ): Promise<Artifact[]> {
-    const res = await this.#octokit.actions.listWorkflowRunArtifacts({
-      owner,
-      repo,
-      run_id: runId,
-    });
+    const artifactsResponse =
+      await this.#octokit.actions.listWorkflowRunArtifacts({
+        owner,
+        repo,
+        run_id: runId,
+      });
 
     // Unarchive zip artifacts
     const zipExtractor = new ZipExtractor();
     try {
-      const artifactZipData = await Promise.all(
-        res.data.artifacts.map(async (artifact) => {
-          const zipData = await this.downloadArtifact(owner, repo, runId, {
-            id: artifact.id,
-            name: artifact.name,
-          });
+      const downloadedArtifacts = await Promise.all(
+        artifactsResponse.data.artifacts.map(async (artifact) => {
+          const downloadedArtifact = await this.downloadArtifact(
+            owner,
+            repo,
+            runId,
+            {
+              name: artifact.name,
+              archiveDownloadUrl: artifact.archive_download_url,
+            },
+          );
 
           return {
             name: artifact.name,
-            zipData,
+            downloadedArtifact,
           };
         }),
       );
 
-      for (const { name, zipData } of artifactZipData) {
-        if (!zipData) continue;
+      const directArtifacts: Artifact[] = [];
+      for (const { name, downloadedArtifact } of downloadedArtifacts) {
+        if (!downloadedArtifact) continue;
 
-        await zipExtractor.put(name, zipData);
+        if (downloadedArtifact.format === "zip") {
+          await zipExtractor.put(name, downloadedArtifact.data);
+          continue;
+        }
+
+        const directArtifact = toDirectArtifact(
+          downloadedArtifact.path,
+          downloadedArtifact.data,
+          globs,
+        );
+        if (directArtifact) {
+          directArtifacts.push(directArtifact);
+        }
       }
 
       const zipEntries = zipExtractor.extract(globs);
 
-      return zipEntries.map((entry) => {
-        return {
-          path: entry.entryName,
-          data: entry.getData().buffer.slice(0) as ArrayBuffer,
-        };
-      });
+      return [
+        ...zipEntries.map((entry) => {
+          return {
+            path: entry.entryName,
+            data: entry.getData().buffer.slice(0) as ArrayBuffer,
+          };
+        }),
+        ...directArtifacts,
+      ];
     } finally {
       await zipExtractor.rmTmpZip();
     }

--- a/tests/client/github_artifact.test.ts
+++ b/tests/client/github_artifact.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectGithubArtifactFormat,
+  resolveGithubArtifactPath,
+} from "../../src/client/github_artifact.ts";
+
+describe("github_artifact", () => {
+  describe("detectGithubArtifactFormat", () => {
+    it("detects zip payloads from their signature", () => {
+      const data = Uint8Array.from([0x50, 0x4b, 0x03, 0x04]).buffer;
+
+      expect(detectGithubArtifactFormat(data)).toBe("zip");
+    });
+
+    it("treats non-zip payloads as files", () => {
+      const data = Uint8Array.from([0x1f, 0x8b, 0x08, 0x00]).buffer;
+
+      expect(detectGithubArtifactFormat(data)).toBe("file");
+    });
+  });
+
+  describe("resolveGithubArtifactPath", () => {
+    it("trims whitespace before removing surrounding quotes", () => {
+      const headers = new Headers({
+        "content-disposition": 'attachment; filename="artifact.zip" ',
+      });
+
+      expect(resolveGithubArtifactPath(headers, "fallback")).toBe(
+        "artifact.zip",
+      );
+    });
+
+    it("prefers filename* when GitHub returns a UTF-8 encoded filename", () => {
+      const headers = new Headers({
+        "content-disposition":
+          "attachment; filename=fallback.txt; filename*=UTF-8''test%20results.xml",
+      });
+
+      expect(resolveGithubArtifactPath(headers, "fallback")).toBe(
+        "test results.xml",
+      );
+    });
+
+    it("removes surrounding quotes from UTF-8 encoded filenames", () => {
+      const headers = new Headers({
+        "content-disposition": `attachment; filename=fallback.txt; filename*=UTF-8''"test%20results.xml"`,
+      });
+
+      expect(resolveGithubArtifactPath(headers, "fallback")).toBe(
+        "test results.xml",
+      );
+    });
+  });
+});

--- a/tests/client/github_client.test.ts
+++ b/tests/client/github_client.test.ts
@@ -37,6 +37,10 @@ type MockDownloadedArtifactResponse = {
   headers: Headers;
 };
 
+type MockArtifactDownloadOctokit = {
+  request: ReturnType<typeof vi.fn>;
+};
+
 const defaultOptions = new ArgumentOptions({
   c: "./dummy.yaml",
 });
@@ -90,19 +94,35 @@ function createGithubClient(
   artifacts: MockArtifact[],
   downloadedArtifact: MockDownloadedArtifactResponse,
 ): {
+  artifactDownloadOctokit: MockArtifactDownloadOctokit;
   client: GithubClient;
   octokit: ReturnType<typeof createMockOctokit>;
 } {
   const octokit = createMockOctokit(artifacts);
+  const artifactDownloadOctokit = {
+    request: vi.fn(async () => ({
+      data: downloadedArtifact.data,
+      headers: Object.fromEntries(downloadedArtifact.headers.entries()),
+    })),
+  };
   const client = new GithubClient("DUMMY_TOKEN", defaultOptions, undefined, {
+    artifactDownloadOctokit: artifactDownloadOctokit as any,
     octokit,
-    artifactDownloader: vi.fn(async () => downloadedArtifact),
   });
 
   return {
+    artifactDownloadOctokit,
     client,
     octokit,
   };
+}
+
+function expectArtifactBlobDownloadRequested(
+  artifactDownloadOctokit: MockArtifactDownloadOctokit,
+): void {
+  expect(artifactDownloadOctokit.request).toHaveBeenCalledWith(
+    "GET https://example.test/download",
+  );
 }
 
 describe("GithubClient", () => {
@@ -189,7 +209,7 @@ describe("GithubClient", () => {
 
   describe("fetchArtifacts", () => {
     it("extracts files from zip artifacts", async () => {
-      const { client } = createGithubClient(
+      const { artifactDownloadOctokit, client } = createGithubClient(
         [
           {
             id: 1,
@@ -214,10 +234,11 @@ describe("GithubClient", () => {
 
       expect(artifacts).toHaveLength(1);
       expect(artifacts[0]?.path).toBe("reports/junit.xml");
+      expectArtifactBlobDownloadRequested(artifactDownloadOctokit);
     });
 
     it("treats matching non-zip artifacts as direct files", async () => {
-      const { client, octokit } = createGithubClient(
+      const { artifactDownloadOctokit, client, octokit } = createGithubClient(
         [
           {
             id: 1,
@@ -246,6 +267,7 @@ describe("GithubClient", () => {
           data: expect.any(ArrayBuffer),
         },
       ]);
+      expectArtifactBlobDownloadRequested(artifactDownloadOctokit);
       expect(octokit.request).toHaveBeenCalledWith(
         "GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}",
         {
@@ -266,7 +288,7 @@ describe("GithubClient", () => {
     });
 
     it("skips non-zip artifacts quietly even when headers say zip", async () => {
-      const { client, octokit } = createGithubClient(
+      const { artifactDownloadOctokit, client, octokit } = createGithubClient(
         [
           {
             id: 1,
@@ -291,11 +313,12 @@ describe("GithubClient", () => {
       );
 
       expect(artifacts).toEqual([]);
+      expectArtifactBlobDownloadRequested(artifactDownloadOctokit);
       expect(octokit.log.warn).not.toHaveBeenCalled();
     });
 
     it("falls back to payload sniffing when zip content-type is missing", async () => {
-      const { client } = createGithubClient(
+      const { artifactDownloadOctokit, client } = createGithubClient(
         [
           {
             id: 1,
@@ -320,6 +343,7 @@ describe("GithubClient", () => {
 
       expect(artifacts).toHaveLength(1);
       expect(artifacts[0]?.path).toBe("reports/junit.xml");
+      expectArtifactBlobDownloadRequested(artifactDownloadOctokit);
     });
   });
 });

--- a/tests/client/github_client.test.ts
+++ b/tests/client/github_client.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import AdmZip from "adm-zip";
 import { ArgumentOptions } from "../../src/arg_options.ts";
 import { GithubClient } from "../../src/client/github_client.ts";
 
@@ -26,14 +27,84 @@ const hasQueuedRuns = [
   { run_number: 6, status: "completed" },
 ] as any;
 
+type MockArtifact = {
+  name: string;
+  archive_download_url: string;
+};
+
+type MockDownloadedArtifactResponse = {
+  data: ArrayBuffer;
+  headers: Headers;
+};
+
+const defaultOptions = new ArgumentOptions({
+  c: "./dummy.yaml",
+});
+const xmlGlobs = ["**/*.xml"];
+
+function createZipArrayBuffer(path: string, content: string): ArrayBuffer {
+  const zip = new AdmZip();
+  zip.addFile(path, Buffer.from(content));
+  const buffer = zip.toBuffer();
+  return buffer.buffer.slice(
+    buffer.byteOffset,
+    buffer.byteOffset + buffer.byteLength,
+  );
+}
+
+function createArrayBuffer(content: string): ArrayBuffer {
+  const buffer = Buffer.from(content);
+  return buffer.buffer.slice(
+    buffer.byteOffset,
+    buffer.byteOffset + buffer.byteLength,
+  );
+}
+
+function createMockOctokit(artifacts: MockArtifact[] = []) {
+  return {
+    log: {
+      warn: vi.fn(),
+    },
+    actions: {
+      listWorkflowRuns: vi.fn(),
+      listRepoWorkflows: vi.fn(),
+      listJobsForWorkflowRun: vi.fn(),
+      listWorkflowRunArtifacts: vi.fn(async () => ({
+        data: {
+          artifacts,
+        },
+      })),
+    },
+    repos: {
+      listTags: vi.fn(),
+    },
+  } as any;
+}
+
+function createGithubClient(
+  artifacts: MockArtifact[],
+  downloadedArtifact: MockDownloadedArtifactResponse,
+): {
+  client: GithubClient;
+  octokit: ReturnType<typeof createMockOctokit>;
+} {
+  const octokit = createMockOctokit(artifacts);
+  const client = new GithubClient("DUMMY_TOKEN", defaultOptions, undefined, {
+    octokit,
+    artifactDownloader: vi.fn(async () => downloadedArtifact),
+  });
+
+  return {
+    client,
+    octokit,
+  };
+}
+
 describe("GithubClient", () => {
   describe("filterWorkflowRuns", () => {
     let client: GithubClient;
-    const options = new ArgumentOptions({
-      c: "./dummy.yaml",
-    });
     beforeEach(() => {
-      client = new GithubClient("DUMMY_TOKEN", options);
+      client = new GithubClient("DUMMY_TOKEN", defaultOptions);
     });
 
     it("when lastRunId is undef and has not in_pregress runs", async () => {
@@ -81,11 +152,8 @@ describe("GithubClient", () => {
 
   describe("filterWorkflows", () => {
     let client: GithubClient;
-    const options = new ArgumentOptions({
-      c: "./dummy.yaml",
-    });
     beforeEach(() => {
-      client = new GithubClient("DUMMY_TOKEN", options);
+      client = new GithubClient("DUMMY_TOKEN", defaultOptions);
     });
 
     it("when workflows have CodeQL workflow", async () => {
@@ -111,6 +179,126 @@ describe("GithubClient", () => {
         { name: "Release", path: ".github/workflows/release.yml" },
         { name: "Test", path: ".github/workflows/test.yml" },
       ]);
+    });
+  });
+
+  describe("fetchArtifacts", () => {
+    it("extracts files from zip artifacts", async () => {
+      const { client } = createGithubClient(
+        [
+          {
+            name: "test_results",
+            archive_download_url: "https://example.test/artifacts/1",
+          },
+        ],
+        {
+          data: createZipArrayBuffer("reports/junit.xml", "<testsuite />"),
+          headers: new Headers({
+            "content-type": "application/zip",
+            "content-disposition": 'attachment; filename="test_results.zip"',
+          }),
+        },
+      );
+
+      const artifacts = await client.fetchArtifacts(
+        "owner",
+        "repo",
+        1,
+        xmlGlobs,
+      );
+
+      expect(artifacts).toHaveLength(1);
+      expect(artifacts[0]?.path).toBe("reports/junit.xml");
+    });
+
+    it("treats matching non-zip artifacts as direct files", async () => {
+      const { client, octokit } = createGithubClient(
+        [
+          {
+            name: "artifact",
+            archive_download_url: "https://example.test/artifacts/1",
+          },
+        ],
+        {
+          data: createArrayBuffer("<testsuite />"),
+          headers: new Headers({
+            "content-type": "application/octet-stream",
+            "content-disposition": 'attachment; filename="test-results.xml"',
+          }),
+        },
+      );
+
+      const artifacts = await client.fetchArtifacts(
+        "owner",
+        "repo",
+        1,
+        xmlGlobs,
+      );
+
+      expect(artifacts).toEqual([
+        {
+          path: "test-results.xml",
+          data: expect.any(ArrayBuffer),
+        },
+      ]);
+      expect(octokit.log.warn).not.toHaveBeenCalled();
+    });
+
+    it("skips non-zip artifacts quietly even when headers say zip", async () => {
+      const { client, octokit } = createGithubClient(
+        [
+          {
+            name: "artifact",
+            archive_download_url: "https://example.test/artifacts/1",
+          },
+        ],
+        {
+          data: createArrayBuffer("buildkit data"),
+          headers: new Headers({
+            "content-type": "application/zip",
+            "content-disposition":
+              'attachment; filename="artifact.dockerbuild.zip"',
+          }),
+        },
+      );
+
+      const artifacts = await client.fetchArtifacts(
+        "owner",
+        "repo",
+        1,
+        xmlGlobs,
+      );
+
+      expect(artifacts).toEqual([]);
+      expect(octokit.log.warn).not.toHaveBeenCalled();
+    });
+
+    it("falls back to payload sniffing when zip content-type is missing", async () => {
+      const { client } = createGithubClient(
+        [
+          {
+            name: "artifact",
+            archive_download_url: "https://example.test/artifacts/1",
+          },
+        ],
+        {
+          data: createZipArrayBuffer("reports/junit.xml", "<testsuite />"),
+          headers: new Headers({
+            "content-type": "application/octet-stream",
+            "content-disposition": 'attachment; filename="artifact.bin"',
+          }),
+        },
+      );
+
+      const artifacts = await client.fetchArtifacts(
+        "owner",
+        "repo",
+        1,
+        xmlGlobs,
+      );
+
+      expect(artifacts).toHaveLength(1);
+      expect(artifacts[0]?.path).toBe("reports/junit.xml");
     });
   });
 });

--- a/tests/client/github_client.test.ts
+++ b/tests/client/github_client.test.ts
@@ -28,8 +28,8 @@ const hasQueuedRuns = [
 ] as any;
 
 type MockArtifact = {
+  id: number;
   name: string;
-  archive_download_url: string;
 };
 
 type MockDownloadedArtifactResponse = {
@@ -78,6 +78,11 @@ function createMockOctokit(artifacts: MockArtifact[] = []) {
     repos: {
       listTags: vi.fn(),
     },
+    request: vi.fn(async () => ({
+      headers: {
+        location: "https://example.test/download",
+      },
+    })),
   } as any;
 }
 
@@ -187,8 +192,8 @@ describe("GithubClient", () => {
       const { client } = createGithubClient(
         [
           {
+            id: 1,
             name: "test_results",
-            archive_download_url: "https://example.test/artifacts/1",
           },
         ],
         {
@@ -215,8 +220,8 @@ describe("GithubClient", () => {
       const { client, octokit } = createGithubClient(
         [
           {
+            id: 1,
             name: "artifact",
-            archive_download_url: "https://example.test/artifacts/1",
           },
         ],
         {
@@ -241,6 +246,22 @@ describe("GithubClient", () => {
           data: expect.any(ArrayBuffer),
         },
       ]);
+      expect(octokit.request).toHaveBeenCalledWith(
+        "GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}",
+        {
+          owner: "owner",
+          repo: "repo",
+          artifact_id: 1,
+          archive_format: "zip",
+          headers: {
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+          request: {
+            parseSuccessResponseBody: false,
+            redirect: "manual",
+          },
+        },
+      );
       expect(octokit.log.warn).not.toHaveBeenCalled();
     });
 
@@ -248,8 +269,8 @@ describe("GithubClient", () => {
       const { client, octokit } = createGithubClient(
         [
           {
+            id: 1,
             name: "artifact",
-            archive_download_url: "https://example.test/artifacts/1",
           },
         ],
         {
@@ -277,8 +298,8 @@ describe("GithubClient", () => {
       const { client } = createGithubClient(
         [
           {
+            id: 1,
             name: "artifact",
-            archive_download_url: "https://example.test/artifacts/1",
           },
         ],
         {


### PR DESCRIPTION
fix: #1801 

## Summary
- detect GitHub artifact format from the payload instead of assuming every downloaded artifact is a ZIP archive
  - upload-artifact may uploaded non-zip file as artifact. ref: https://github.com/actions/upload-artifact/releases/tag/v7.0.0 
- extract ZIP artifacts as before and treat matching non-ZIP artifacts as direct-file candidates under the existing path globs
- add regression tests for ZIP artifacts, direct-file artifacts, and mislabeled non-ZIP artifacts

## Test plan
- [x] `npm run biome:ci`
- [x] `npm run check`
- [x] `npm test`
- [x] Run the CLI against the real GitHub-only validation config

🤖 Generated with [Claude Code](https://claude.com/claude-code)