### PR TITLE
Fix container CLI command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,9 @@ jobs:
           tags: ghcr.io/kesin11/ci_analyzer:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Smoke test container CLI command
+        run: |
+          docker run --rm --entrypoint sh ghcr.io/kesin11/ci_analyzer:latest -c '
+            ci_analyzer --version &&
+            ci_analyzer --help >/dev/null
+          '

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,7 @@ COPY README.md LICENSE ci_analyzer.yaml ./
 COPY src ./src
 COPY bigquery_schema ./bigquery_schema
 
+RUN ln -s /ci_analyzer/src/index.ts /usr/local/bin/ci_analyzer
+
 ENTRYPOINT ["/usr/bin/tini", "--", "/ci_analyzer/src/index.ts"]
 WORKDIR /app


### PR DESCRIPTION
## Summary
- restore the `ci_analyzer` command in the runtime image by linking the current TypeScript entrypoint into `/usr/local/bin`
  - It removed by https://github.com/Kesin11/CIAnalyzer/pull/1797
- add a container smoke test in CI so the command path used by the sample cron workflows stays covered

## Test plan
- [x] `mise exec node@24.15.0 -- npm run check`
- [x] `mise exec node@24.15.0 -- npm test`
- [x] run the CLI locally with the real validation config
- [x] build the container image and run it with the same validation config

🤖 Generated with GitHub Copilot CLI
